### PR TITLE
Add task links directly to WindowsSettings.json

### DIFF
--- a/Classes/WindowsSetting.cs
+++ b/Classes/WindowsSetting.cs
@@ -48,6 +48,16 @@ namespace Flow.Plugin.WindowsSettings.Classes
         public IEnumerable<string>? AltNames { get; set; }
 
         /// <summary>
+        /// Gets or sets the Keywords names of this task link.
+        /// </summary>
+        public IEnumerable<IEnumerable<string>>? Keywords { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Ghyph of this setting
+        /// </summary>
+        public string? glyph { get; set; }
+
+        /// <summary>
         /// Gets or sets a additional note of this settings.
         /// <para>(e.g. why is not supported on your system)</para>
         /// </summary>

--- a/Flow.Plugin.WindowsSettings.sln
+++ b/Flow.Plugin.WindowsSettings.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31512.422
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Flow.Plugin.WindowsSettings", "Flow.Plugin.WindowsSettings.csproj", "{5043CECE-E6A7-4867-9CBE-02D27D83747A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5043CECE-E6A7-4867-9CBE-02D27D83747A}.Debug|x64.ActiveCfg = Debug|x64
+		{5043CECE-E6A7-4867-9CBE-02D27D83747A}.Debug|x64.Build.0 = Debug|x64
+		{5043CECE-E6A7-4867-9CBE-02D27D83747A}.Release|x64.ActiveCfg = Release|x64
+		{5043CECE-E6A7-4867-9CBE-02D27D83747A}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EA85E245-28F0-4192-B9E7-6FA8CFF3D3CD}
+	EndGlobalSection
+EndGlobal

--- a/Helper/ResultHelper.cs
+++ b/Helper/ResultHelper.cs
@@ -69,7 +69,20 @@ namespace Flow.Plugin.WindowsSettings.Helper
                             .FirstOrDefault();
                     }
 
+                    if (result is null && entry.Keywords is not null)
+                    {
+                        string[] searchKeywords = query.Terms[(string.IsNullOrEmpty(query.ActionKeyword) ? 0 : 1)..];
+
+                        if (searchKeywords
+                            .All(x => entry
+                                .Keywords
+                                .SelectMany(x => x)
+                                .Contains(x, StringComparer.CurrentCultureIgnoreCase))
+                        )
+                            result = NewSettingResult(midScore);
+                    }
                 }
+
                 if (result is null)
                     continue;
 
@@ -82,7 +95,7 @@ namespace Flow.Plugin.WindowsSettings.Helper
                     Action = _ => DoOpenSettingsAction(entry),
                     IcoPath = iconPath,
                     SubTitle = $"{Resources.Area} \"{entry.Area}\" {Resources.SubtitlePreposition} {entry.Type}",
-                    Title = entry.Name,
+                    Title = entry.Name + entry.glyph,
                     ContextData = entry,
                     Score = score
                 };

--- a/WindowsSettings.json
+++ b/WindowsSettings.json
@@ -1735,5 +1735,12267 @@
     "Type": "ControlPanel",
     "AltNames": [ "wgpocpl.cpl" ],
     "Command": "control Wgpocpl.cpl"
+  },
+  {
+    "Name": "Accommodate learning abilities",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageQuestionsCognitive",
+    "Keywords": [
+      [
+        "accomidate",
+        "accomodates",
+        "accomodating",
+        "adjust",
+        "for" 
+      ],
+      [
+        "can",
+        "not",
+        "cannot",
+        "can't",
+        "difficult",
+        "to",
+        "difficulty",
+        "does",
+        "doesn't",
+        "hard",
+        "not",
+        "will",
+        "willnot",
+        "won't"
+      ],
+      [
+        "disabled",
+        "handicap",
+        "handicapped",
+        "disabilities",
+        "disability",
+        "empaired",
+        "impaired",
+        "imparied",
+        "trouble"
+      ],
+      [
+        "cognitive",
+        "learning"
+      ]
+    ]
+  },
+  {
+    "Name": "Accommodate low vision",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "accomidate",
+        "accomodates",
+        "accomodating",
+        "adjust",
+        "for"
+      ],
+      [
+        "site",
+        "blindness",
+        "blurred",
+        "blurry",
+        "half",
+        "legally",
+        "low",
+        "vision",
+        "poor",
+        "seeing",
+        "seems",
+        "sight",
+        "weak",
+        "bad",
+        "eyesight",
+        "eye-sight"
+      ],
+      [
+        "disabled",
+        "handicap",
+        "handicapped",
+        "disabilities",
+        "disability",
+        "empaired",
+        "impaired",
+        "imparied",
+        "trouble"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how your keyboard works",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageKeyboardEasierToUse",
+    "Keywords": [
+      [
+        "switch",
+        "filterkeys",
+        "keys",
+        "stickykeys",
+        "togglekeys",
+        "sticky-keys",
+        "toggle-keys",
+        "repeat",
+        "delay",
+        "hold",
+        "down",
+        "rate"
+      ],
+      [
+        "accessibility",
+        "acessibility",
+        "ease",
+        "of"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how your mouse works",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToClick",
+    "Keywords": [
+      [
+        "accessibility",
+        "acessibility",
+        "ease",
+        "of"
+      ],
+      [
+        "butons",
+        "buttons"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "lock",
+        "clicking",
+        "doubleclick",
+        "double-click",
+        "single-click"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "move",
+        "moving",
+        "shadow",
+        "speed",
+        "tails"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ]
+    ]
+  },
+  {
+    "Name": "Use screen reader",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageNoVisual",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "screan",
+        "readers",
+        "screenreader",
+        "windows",
+        "narrator"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the Narrator\u2019s voice",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\narrator.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "sound",
+        "voices"
+      ],
+      [
+        "screan",
+        "readers",
+        "screenreader",
+        "windows",
+        "narrator"
+      ]
+    ]
+  },
+  {
+    "Name": "Control the computer without the mouse or keyboard",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageNoMouseOrKeyboard",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ]
+    ]
+  },
+  {
+    "Name": "Hear a tone when keys are pressed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageFilterKeysSettings",
+    "Keywords": [
+      [
+        "def",
+        "hearing",
+        "deaf",
+        "deafness",
+        "hard",
+        "of",
+        "problem",
+        "impaired",
+        "imparied"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ],
+      [
+        "customise",
+        "soundsentry",
+        "sentry",
+        "settings",
+        "customize",
+        "captions",
+        "showsounds"
+      ]
+    ]
+  },
+  {
+    "Name": "Hear text read aloud with Narrator",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter",
+    "Keywords": [
+      [
+        "read",
+        "reads",
+        "reading"
+      ],
+      [
+        "screan",
+        "readers",
+        "screenreader",
+        "windows",
+        "narrator"
+      ]
+    ]
+  },
+  {
+    "Name": "Ignore repeated keystrokes using FilterKeys",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageFilterKeysSettings",
+    "Keywords": [
+      [
+        "keys",
+        "filterkeys"
+      ]
+    ]
+  },
+  {
+    "Name": "Let Windows suggest Ease of Access settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageQuestionsEyesight",
+    "Keywords": [
+      [
+        "accessibility",
+        "acessibility",
+        "ease",
+        "of"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "questionaire",
+        "questionnaire",
+        "survey"
+      ],
+      [
+        "wizard",
+        "wizzard"
+      ]
+    ]
+  },
+  {
+    "Name": "Magnify portions of the screen using Magnifier",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "site",
+        "blindness",
+        "blurred",
+        "blurry",
+        "half",
+        "legally",
+        "low",
+        "vision",
+        "poor",
+        "seeing",
+        "seems",
+        "sight",
+        "weak",
+        "bad",
+        "eyesight",
+        "eye-sight"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "magnification",
+        "magnified",
+        "magnifying",
+        "make",
+        "bigger",
+        "larger",
+        "zoom",
+        "in"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Move the pointer with the keypad using MouseKeys",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageKeyboardEasierToUse",
+    "Keywords": [
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "keys",
+        "mousekeys"
+      ]
+    ]
+  },
+  {
+    "Name": "Optimise for blindness",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageNoVisual",
+    "Keywords": [
+      [
+        "site",
+        "blindness",
+        "blurred",
+        "blurry",
+        "half",
+        "legally",
+        "low",
+        "vision",
+        "poor",
+        "seeing",
+        "seems",
+        "sight",
+        "weak",
+        "bad",
+        "eyesight",
+        "eye-sight"
+      ],
+      [
+        "can",
+        "not",
+        "cannot",
+        "can't",
+        "difficult",
+        "to",
+        "difficulty",
+        "does",
+        "doesn't",
+        "hard",
+        "not",
+        "will",
+        "willnot",
+        "won't"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "dimmed",
+        "dimed",
+        "low",
+        "dimming",
+        "diming",
+        "dimmer",
+        "dimer",
+        "display",
+        "fade",
+        "brightness"
+      ],
+      [
+        "disabled",
+        "handicap",
+        "handicapped",
+        "disabilities",
+        "disability",
+        "empaired",
+        "impaired",
+        "imparied",
+        "trouble"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Optimise visual display",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "switch",
+        "filterkeys",
+        "keys",
+        "stickykeys",
+        "togglekeys",
+        "sticky-keys",
+        "toggle-keys",
+        "repeat",
+        "delay",
+        "hold",
+        "down",
+        "rate"
+      ],
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "site",
+        "blindness",
+        "blurred",
+        "blurry",
+        "half",
+        "legally",
+        "low",
+        "vision",
+        "poor",
+        "seeing",
+        "seems",
+        "sight",
+        "weak",
+        "bad",
+        "eyesight",
+        "eye-sight"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Press key combinations one at a time",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageKeyboardEasierToUse",
+    "Keywords": [
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ],
+      [
+        "keys",
+        "stickykeys"
+      ]
+    ]
+  },
+  {
+    "Name": "Replace sounds with visual cues",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierWithSounds",
+    "Keywords": [
+      [
+        "can",
+        "not",
+        "cannot",
+        "can't",
+        "difficult",
+        "to",
+        "difficulty",
+        "does",
+        "doesn't",
+        "hard",
+        "not",
+        "will",
+        "willnot",
+        "won't"
+      ],
+      [
+        "def",
+        "hearing",
+        "deaf",
+        "deafness",
+        "hard",
+        "of",
+        "problem",
+        "impaired",
+        "imparied"
+      ],
+      [
+        "disabled",
+        "handicap",
+        "handicapped",
+        "disabilities",
+        "disability",
+        "empaired",
+        "impaired",
+        "imparied",
+        "trouble"
+      ],
+      [
+        "cards",
+        "soundcards"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ],
+      [
+        "customise",
+        "soundsentry",
+        "sentry",
+        "settings",
+        "customize",
+        "captions",
+        "showsounds"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn High Contrast on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL desk.cpl,,2",
+    "Keywords": [
+      [
+        "brightness",
+        "contrast",
+        "hi-contrast",
+        "high-contrast"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "monitors",
+        "screens"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn Magnifier on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "magnification",
+        "magnified",
+        "magnifying",
+        "make",
+        "bigger",
+        "larger",
+        "zoom",
+        "in"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn off background images",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "ground",
+        "background"
+      ],
+      [
+        "image",
+        "photograph",
+        "picture"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn off unnecessary animations",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "animations",
+        "cartoons"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn On-Screen keyboard on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ],
+      [
+        "screen",
+        "keyboard",
+        "onscreen",
+        "on-screen",
+        "osk"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn on easy access keys",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageKeyboardEasierToUse",
+    "Keywords": [
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ]
+    ]
+  },
+  {
+    "Name": "Use audio description for video",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToSee",
+    "Keywords": [
+      [
+        "text",
+        "to",
+        "speech",
+        "tts",
+        "voice",
+        "narrator"
+      ],
+      [
+        "videoes",
+        "videos"
+      ]
+    ]
+  },
+  {
+    "Name": "View current accessibility settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter",
+    "Keywords": [
+      [
+        "accessibility",
+        "acessibility",
+        "ease",
+        "of"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn off automatic window arrangement",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.EaseOfAccessCenter /page pageEasierToClick",
+    "Keywords": [
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "management",
+        "managment"
+      ],
+      [
+        "movement",
+        "movment",
+        "movemnet",
+        "motion"
+      ],
+      [
+        "maximise",
+        "minimise",
+        "snapping",
+        "shake",
+        "shaking",
+        "dock",
+        "drag",
+        "edge",
+        "sides",
+        "top",
+        "screen",
+        "size",
+        "resize",
+        "maximize",
+        "restore",
+        "minimize"
+      ]
+    ]
+  },
+  {
+    "Name": "Create and format hard disk partitions",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\diskmgmt.msc",
+    "Keywords": [
+      [
+        "clean-up",
+        "check",
+        "disk",
+        "dsk",
+        "chkdsk",
+        "cleandisk",
+        "cleaner",
+        "cleanup",
+        "up"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "fdisc",
+        "fdisk"
+      ],
+      [
+        "formated",
+        "formating",
+        "formatted",
+        "formatting"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "boot",
+        "disc",
+        "extended",
+        "format",
+        "disk",
+        "drive",
+        "harddisk",
+        "harddrive",
+        "ntfs",
+        "fat",
+        "partitian",
+        "partitioning",
+        "primary",
+        "reformat",
+        "sector",
+        "unpartition",
+        "volume"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ],
+      [
+        "management",
+        "managment"
+      ]
+    ]
+  },
+  {
+    "Name": "Defragment and optimise your drives",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\dfrgui.exe",
+    "Keywords": [
+      [
+        "clean-up",
+        "check",
+        "disk",
+        "dsk",
+        "chkdsk",
+        "cleandisk",
+        "cleaner",
+        "cleanup",
+        "up"
+      ],
+      [
+        "defragment",
+        "free",
+        "up",
+        "space"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "disc",
+        "disk",
+        "scandisc",
+        "scandisk",
+        "scandsk"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Diagnose your computer's memory problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mdsched.exe",
+    "Keywords": [
+      [
+        "diagnose",
+        "diagnostics",
+        "diagnosis",
+        "find",
+        "problems",
+        "analyse",
+        "analyze",
+        "analysis",
+        "troubleshooter",
+        "errors"
+      ],
+      [
+        "gigabytes",
+        "gigs",
+        "megabytes",
+        "megs",
+        "memory",
+        "ram"
+      ]
+    ]
+  },
+  {
+    "Name": "Edit group policy",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\gpedit.msc",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "grouping"
+      ],
+      [
+        "policies",
+        "policys"
+      ]
+    ]
+  },
+  {
+    "Name": "Clear disk space by deleting unnecessary files",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\cleanmgr.exe",
+    "Keywords": [
+      [
+        "clean-up",
+        "check",
+        "disk",
+        "dsk",
+        "chkdsk",
+        "cleandisk",
+        "cleaner",
+        "cleanup",
+        "up"
+      ],
+      [
+        "clean-up",
+        "check",
+        "up",
+        "cleanup",
+        "free",
+        "space",
+        "room",
+        "release",
+        "available"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "temp",
+        "cached",
+        "files",
+        "history",
+        "local",
+        "temorary",
+        "temporary",
+        "temperary",
+        "tmp",
+        "unnecessary",
+        "unneeded",
+        "useless",
+        "web"
+      ]
+    ]
+  },
+  {
+    "Name": "Generate a system health report",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\perfmon.exe /report",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "healthy"
+      ],
+      [
+        "optimise",
+        "crawl",
+        "degrade",
+        "faster",
+        "frozen",
+        "hanging",
+        "hung",
+        "improve",
+        "inactive",
+        "optimize",
+        "performance",
+        "quicker",
+        "sluggish",
+        "speed",
+        "thrashing",
+        "too",
+        "slow",
+        "unresponsive"
+      ],
+      [
+        "diagnose",
+        "diagnostics",
+        "diagnosis",
+        "find",
+        "problems",
+        "analyse",
+        "analyze",
+        "analysis",
+        "troubleshooter",
+        "errors"
+      ]
+    ]
+  },
+  {
+    "Name": "Schedule tasks",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\taskschd.msc",
+    "Keywords": [
+      [
+        "automated",
+        "automatically"
+      ],
+      [
+        "scheduled",
+        "scheduling"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up ODBC data sources",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\odbcad32.exe",
+    "Keywords": [
+      [
+        "datum",
+        "odbc",
+        "data-base",
+        "database"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up ODBC data sources (32-bit)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\syswow64\\odbcad32.exe",
+    "Keywords": [
+      [
+        "datum",
+        "odbc",
+        "data-base",
+        "database"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up ODBC data sources (64-bit)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\odbcad32.exe",
+    "Keywords": [
+      [
+        "datum",
+        "odbc",
+        "data-base",
+        "database"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up ODBC data sources",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\odbcad32.exe",
+    "Keywords": [
+      [
+        "datum",
+        "odbc",
+        "data-base",
+        "database"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up iSCSI initiator",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\iscsicpl.exe",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "iscsi",
+        "scsi"
+      ],
+      [
+        "storage"
+      ]
+    ]
+  },
+  {
+    "Name": "View event logs",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\eventvwr.msc",
+    "Keywords": [
+      [
+        "viewer",
+        "events",
+        "tracker",
+        "eventviewer"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "View event logs",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\eventvwr.msc",
+    "Keywords": [
+      [
+        "viewer",
+        "events",
+        "tracker",
+        "eventviewer"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "View local services",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\services.msc",
+    "Keywords": [
+      [
+        "disable",
+        "stop"
+      ],
+      [
+        "services"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage computer certificates",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\certlm.msc",
+    "Keywords": [
+      [
+        "certificate",
+        "key"
+      ]
+    ]
+  },
+  {
+    "Name": "Uninstall a program",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ProgramsAndFeatures",
+    "Keywords": [
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "browsers",
+        "ie",
+        "microsoft",
+        "windows"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "deinstall",
+        "uninstalled",
+        "uninstalling",
+        "uninstalls",
+        "unistall"
+      ]
+    ]
+  },
+  {
+    "Name": "Add or remove programs",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ProgramsAndFeatures",
+    "Keywords": [
+      [
+        "add",
+        "or",
+        "remove",
+        "programs",
+        "and",
+        "arp"
+      ]
+    ]
+  },
+  {
+    "Name": "View installed updates",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ProgramsAndFeatures /page ::{D450A8A1-9568-45C7-9C0E-B4F9FB4537BD}",
+    "Keywords": [
+      [
+        "previous",
+        "old",
+        "installed",
+        "already",
+        "previously"
+      ],
+      [
+        "atuo",
+        "automatically",
+        "automaticupdates",
+        "autoupdate",
+        "fixes",
+        "bugfixes",
+        "bugs",
+        "download",
+        "live",
+        "microsoft",
+        "patches",
+        "scan",
+        "security",
+        "service",
+        "packs",
+        "dater",
+        "dates",
+        "dating",
+        "updater",
+        "up-dater",
+        "updater.exe",
+        "updates",
+        "up-dates",
+        "up-dating",
+        "windows",
+        "windowsupdate.com",
+        "wizard",
+        "wupdater"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn Windows features on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\OptionalFeatures.exe",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "accessories",
+        "accessory",
+        "components",
+        "feature",
+        "features",
+        "programs",
+        "tools",
+        "utilities",
+        "utility"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn Windows features on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ServerManager.exe -arw",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "accessories",
+        "accessory",
+        "components",
+        "feature",
+        "features",
+        "programs",
+        "tools",
+        "utilities",
+        "utility"
+      ]
+    ]
+  },
+  {
+    "Name": "Show which programs are installed on your computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ProgramsAndFeatures",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ]
+    ]
+  },
+  {
+    "Name": "How to install a program",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "mshelp://windows/?id=fe7ea80e-52a2-48d6-947a-05e02e78bc37",
+    "Keywords": [
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "browsers",
+        "ie",
+        "microsoft",
+        "windows"
+      ]
+    ]
+  },
+  {
+    "Name": "Install a program from the network",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\8\\::{15EAE92E-F17A-4431-9F28-805E482dAFD4}",
+    "Keywords": [
+      [
+        "add",
+        "or",
+        "remove",
+        "programs",
+        "and",
+        "arp"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ]
+    ]
+  },
+  {
+    "Name": "Change or remove a program",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ProgramsAndFeatures",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "browsers",
+        "ie",
+        "microsoft",
+        "windows"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "deinstall",
+        "uninstalled",
+        "uninstalling",
+        "uninstalls",
+        "unistall"
+      ]
+    ]
+  },
+  {
+    "Name": "16-Bit Application Support",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL ntvdmcpl.dll",
+    "Keywords": [
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "applications",
+        "apps",
+        "application",
+        "app"
+      ],
+      [
+        "apcompat",
+        "appcompat",
+        "compatable",
+        "compatibility",
+        "compatible",
+        "still",
+        "use"
+      ],
+      [
+        "16",
+        "bit",
+        "16-bit",
+        "legacy",
+        "old",
+        "dos",
+        "win31",
+        "emulation",
+        "ntvdm"
+      ]
+    ]
+  },
+  {
+    "Name": "Run programs made for previous versions of Windows",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id PCWDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "applications",
+        "apps",
+        "application",
+        "app"
+      ],
+      [
+        "apcompat",
+        "appcompat",
+        "compatable",
+        "compatibility",
+        "compatible",
+        "still",
+        "use"
+      ],
+      [
+        "earlier",
+        "older"
+      ],
+      [
+        "previous",
+        "old",
+        "installed",
+        "already",
+        "previously"
+      ],
+      [
+        "browsers",
+        "ie",
+        "microsoft",
+        "windows"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ]
+    ]
+  },
+  {
+    "Name": "Make a file type always open in a specific program",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DefaultPrograms /page pageFileAssoc",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "associate",
+        "association",
+        "associations",
+        "extensions",
+        "extentions",
+        "type",
+        "filetype",
+        "open",
+        "with"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ]
+    ]
+  },
+  {
+    "Name": "Set your default programs",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DefaultPrograms /page pageDefaultProgram",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "by",
+        "defaults",
+        "defualt",
+        "standard"
+      ],
+      [
+        "associate",
+        "association",
+        "associations",
+        "extensions",
+        "extentions",
+        "type",
+        "filetype",
+        "open",
+        "with"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "protocols"
+      ]
+    ]
+  },
+  {
+    "Name": "View devices and printers",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DevicesAndPrinters",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "802.1x",
+        "wireless",
+        "wire-less"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ],
+      [
+        "computer",
+        "top",
+        "laptop",
+        "mobile",
+        "pc",
+        "notebook",
+        "portable"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "1394",
+        "controller",
+        "adapter",
+        "adaptor",
+        "audio",
+        "biometric",
+        "cable",
+        "modem",
+        "card",
+        "cd-dvd",
+        "drive",
+        "CRT",
+        "devise",
+        "digial",
+        "camera",
+        "dsl",
+        "dvd",
+        "ethernet",
+        "flat",
+        "panel",
+        "game",
+        "handheld",
+        "scanner",
+        "ware",
+        "hardware",
+        "hardwear",
+        "infrared",
+        "ink-jet",
+        "input",
+        "IrDA",
+        "stick",
+        "joystick",
+        "keyboard",
+        "laser",
+        "printer",
+        "lcd",
+        "Mass",
+        "Storage",
+        "midi",
+        "mixer",
+        "mobile",
+        "monitor",
+        "motherboard",
+        "mouse",
+        "mp3",
+        "player",
+        "mpeg",
+        "music",
+        "player",
+        "network",
+        "optical",
+        "wheel",
+        "mouse",
+        "output",
+        "pen",
+        "plasma",
+        "monitor",
+        "portable",
+        "media",
+        "player",
+        "printer",
+        "raid",
+        "recording",
+        "scanner",
+        "card",
+        "reader",
+        "smartcard",
+        "sound",
+        "tape",
+        "drive",
+        "pad",
+        "touchpad",
+        "ball",
+        "trackball",
+        "tuner",
+        "tv",
+        "USB",
+        "video",
+        "capture",
+        "cards",
+        "view",
+        "USB",
+        "hub",
+        "camera",
+        "webcam",
+        "wheel",
+        "mouse",
+        "wireless",
+        "wlan"
+      ],
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "scaners",
+        "scanners",
+        "scanning"
+      ],
+      [
+        "camaras",
+        "cameras",
+        "camras"
+      ],
+      [
+        "maneger",
+        "manager",
+        "devicemanager",
+        "dma",
+        "managar",
+        "management",
+        "managing",
+        "managment"
+      ],
+      [
+        "drivers"
+      ],
+      [
+        "audio",
+        "blank",
+        "ray",
+        "blue-ray",
+        "blu-ray",
+        "cd-rom",
+        "cds",
+        "dvd",
+        "enhanced",
+        "HD",
+        "media",
+        "super",
+        "video"
+      ],
+      [
+        "tooth",
+        "bluetooth",
+        "blutooth"
+      ],
+      [
+        "cards",
+        "videocards",
+        "videos"
+      ],
+      [
+        "storage"
+      ],
+      [
+        "ware",
+        "hardware-general"
+      ]
+    ]
+  },
+  {
+    "Name": "Add a device",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\DevicePairingWizard.exe",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ],
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "mobile",
+        "handset",
+        "handsets",
+        "phone",
+        "cellphone",
+        "cell",
+        "speakers",
+        "headset",
+        "headsets"
+      ],
+      [
+        "TV",
+        "television"
+      ],
+      [
+        "DLNA",
+        "media",
+        "player",
+        "storage",
+        "NAS"
+      ],
+      [
+        "network",
+        "networking",
+        "networks"
+      ],
+      [
+        "link",
+        "pair",
+        "pairs",
+        "associate",
+        "associates",
+        "add",
+        "adds",
+        "connects",
+        "connect",
+        "setup",
+        "playto",
+        "play"
+      ]
+    ]
+  },
+  {
+    "Name": "Advanced printer setup",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe printui.dll,PrintUIEntryDPIAware /il",
+    "Keywords": [
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ],
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "finding",
+        "locate",
+        "locating",
+        "search",
+        "for",
+        "is",
+        "where's",
+        "the"
+      ],
+      [
+        "gets",
+        "getting",
+        "get-verb"
+      ],
+      [
+        "network",
+        "networking",
+        "networks"
+      ],
+      [
+        "link",
+        "pair",
+        "pairs",
+        "associate",
+        "associates",
+        "add",
+        "adds",
+        "connects",
+        "connect",
+        "setup",
+        "playto",
+        "play"
+      ]
+    ]
+  },
+  {
+    "Name": "Add a Bluetooth device",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\DevicePairingWizard.exe /bluetooth",
+    "Keywords": [
+      [
+        "tooth",
+        "bluetooth",
+        "blutooth"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "802.1x",
+        "wireless",
+        "wire-less"
+      ],
+      [
+        "link",
+        "pair",
+        "pairs",
+        "associate",
+        "associates",
+        "add",
+        "adds",
+        "connects",
+        "connect",
+        "setup",
+        "playto",
+        "play"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ]
+    ]
+  },
+  {
+    "Name": "Device Manager",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DeviceManager",
+    "Keywords": [
+      [
+        "maneger",
+        "manager",
+        "devicemanager",
+        "dma",
+        "managar",
+        "management",
+        "managing",
+        "managment"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "drivers"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "1394",
+        "controller",
+        "adapter",
+        "adaptor",
+        "audio",
+        "biometric",
+        "cable",
+        "modem",
+        "card",
+        "cd-dvd",
+        "drive",
+        "CRT",
+        "devise",
+        "digial",
+        "camera",
+        "dsl",
+        "dvd",
+        "ethernet",
+        "flat",
+        "panel",
+        "game",
+        "handheld",
+        "scanner",
+        "ware",
+        "hardware",
+        "hardwear",
+        "infrared",
+        "ink-jet",
+        "input",
+        "IrDA",
+        "stick",
+        "joystick",
+        "keyboard",
+        "laser",
+        "printer",
+        "lcd",
+        "Mass",
+        "Storage",
+        "midi",
+        "mixer",
+        "mobile",
+        "monitor",
+        "motherboard",
+        "mouse",
+        "mp3",
+        "player",
+        "mpeg",
+        "music",
+        "player",
+        "network",
+        "optical",
+        "wheel",
+        "mouse",
+        "output",
+        "pen",
+        "plasma",
+        "monitor",
+        "portable",
+        "media",
+        "player",
+        "printer",
+        "raid",
+        "recording",
+        "scanner",
+        "card",
+        "reader",
+        "smartcard",
+        "sound",
+        "tape",
+        "drive",
+        "pad",
+        "touchpad",
+        "ball",
+        "trackball",
+        "tuner",
+        "tv",
+        "USB",
+        "video",
+        "capture",
+        "cards",
+        "view",
+        "USB",
+        "hub",
+        "camera",
+        "webcam",
+        "wheel",
+        "mouse",
+        "wireless",
+        "wlan"
+      ],
+      [
+        "mine",
+        "my"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Windows To Go start-up options",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe pwlauncher.dll,ShowPortableWorkspaceLauncherConfigurationUX",
+    "Keywords": []
+  },
+  {
+    "Name": "Change default printer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DevicesAndPrinters",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "by",
+        "defaults",
+        "defualt",
+        "standard"
+      ],
+      [
+        "finding",
+        "locate",
+        "locating",
+        "search",
+        "for",
+        "is",
+        "where's",
+        "the"
+      ],
+      [
+        "gets",
+        "getting",
+        "get-verb"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ]
+    ]
+  },
+  {
+    "Name": "View scanners and cameras",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%ProgramFiles%\\Windows Photo Viewer\\ImagingDevices.exe",
+    "Keywords": [
+      [
+        "camaras",
+        "cameras",
+        "camras"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Bluetooth settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL bthprops.cpl,,1",
+    "Keywords": [
+      [
+        "tooth",
+        "bluetooth",
+        "blutooth"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "802.1x",
+        "wireless",
+        "wire-less"
+      ]
+    ]
+  },
+  {
+    "Name": "Scan a document or picture",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\wfs.exe",
+    "Keywords": [
+      [
+        "scaners",
+        "scanners",
+        "scanning"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up USB game controllers",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL %windir%\\system32\\joy.cpl",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "controlers",
+        "controllers",
+        "stick",
+        "joystick"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "games"
+      ]
+    ]
+  },
+  {
+    "Name": "Change device installation settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe newdev.dll,DeviceInternetSettingUi 5",
+    "Keywords": [
+      [
+        "change",
+        "changing",
+        "devices",
+        "installation",
+        "installing",
+        "settings",
+        "hardware",
+        "drivers",
+        "windows",
+        "in",
+        "out",
+        "optin",
+        "opt-in",
+        "optout",
+        "opt-out",
+        "metadata",
+        "data",
+        "icons",
+        "stage",
+        "downloads",
+        "downloading",
+        "online",
+        "fixing",
+        "working",
+        "my",
+        "searching",
+        "finding",
+        "getting",
+        "doesn't",
+        "not",
+        "for",
+        "newer"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Change settings for content received using Tap and send",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.AutoPlay",
+    "Keywords": [
+      [
+        "nfp",
+        "near",
+        "field",
+        "feild",
+        "proximity",
+        "prosimity",
+        "proxymity",
+        "tap and send"
+      ]
+    ]
+  },
+  {
+    "Name": "Change advanced colour management settings for displays, scanners and printers",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\colorcpl.exe",
+    "Keywords": [
+      [
+        "calibrate",
+        "calibration"
+      ],
+      [
+        "24",
+        "bit",
+        "24-bit",
+        "256",
+        "bit",
+        "32-bit",
+        "colors",
+        "colours",
+        "depth",
+        "num",
+        "number",
+        "of"
+      ],
+      [
+        "absolute",
+        "colorimetric",
+        "gamut",
+        "mapping",
+        "graphics",
+        "images",
+        "perceptual",
+        "proofing",
+        "relative",
+        "rendering",
+        "rgb",
+        "sRGB"
+      ],
+      [
+        "management",
+        "managment"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ],
+      [
+        "scaners",
+        "scanners",
+        "scanning"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Add clocks for different time zones",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL timedate.cpl,,1",
+    "Keywords": [
+      [
+        "additional",
+        "another",
+        "create",
+        "many",
+        "more",
+        "mutliple"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "days",
+        "calendar",
+        "clock",
+        "times",
+        "time",
+        "day"
+      ],
+      [
+        "time zones",
+        "timezone",
+        "time-zone",
+        "zones"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Automatically adjust for daylight saving time",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL timedate.cpl",
+    "Keywords": [
+      [
+        "automated",
+        "automatically"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "days",
+        "calendar",
+        "clock",
+        "times",
+        "time",
+        "day"
+      ],
+      [
+        "light",
+        "daylight",
+        "daylite",
+        "lite",
+        "savings",
+        "savins",
+        "standard"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the time zone",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL timedate.cpl",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "time zones",
+        "timezone",
+        "time-zone",
+        "zones"
+      ]
+    ]
+  },
+  {
+    "Name": "Set the time and date",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL timedate.cpl",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "days",
+        "calendar",
+        "clock",
+        "times",
+        "time",
+        "day"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ]
+    ]
+  },
+  {
+    "Name": "Set the time and date",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL timedate.cpl",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "days",
+        "calendar",
+        "clock",
+        "times",
+        "time",
+        "day"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ]
+    ]
+  },
+  {
+    "Name": "Change default settings for media or devices",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.AutoPlay",
+    "Keywords": [
+      [
+        "play",
+        "run",
+        "start",
+        "autoplay",
+        "auto-play",
+        "autorun",
+        "auto-run",
+        "autostart",
+        "auto-start"
+      ],
+      [
+        "audio",
+        "blank",
+        "ray",
+        "blue-ray",
+        "blu-ray",
+        "cd-rom",
+        "cds",
+        "dvd",
+        "enhanced",
+        "HD",
+        "media",
+        "super",
+        "video"
+      ],
+      [
+        "import",
+        "photo",
+        "connection",
+        "camera",
+        "flash",
+        "removable",
+        "storage",
+        "stage"
+      ]
+    ]
+  },
+  {
+    "Name": "Play CDs or other media automatically",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.AutoPlay",
+    "Keywords": [
+      [
+        "automated",
+        "automatically"
+      ],
+      [
+        "play",
+        "run",
+        "start",
+        "autoplay",
+        "auto-play",
+        "autorun",
+        "auto-run",
+        "autostart",
+        "auto-start"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "audio",
+        "blank",
+        "ray",
+        "blue-ray",
+        "blu-ray",
+        "cd-rom",
+        "cds",
+        "dvd",
+        "enhanced",
+        "HD",
+        "media",
+        "super",
+        "video"
+      ]
+    ]
+  },
+  {
+    "Name": "Start or stop using AutoPlay for all media and devices",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.AutoPlay",
+    "Keywords": [
+      [
+        "play",
+        "run",
+        "start",
+        "autoplay",
+        "auto-play",
+        "autorun",
+        "auto-run",
+        "autostart",
+        "auto-start"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ]
+    ]
+  },
+  {
+    "Name": "Change search options for files and folders",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Options_RunDLL 2",
+    "Keywords": [
+      [
+        "folders",
+        "subfolders"
+      ],
+      [
+        "behaviour",
+        "search",
+        "behavior"
+      ],
+      [
+        "search",
+        "options"
+      ],
+      [
+        "finder",
+        "indexing",
+        "reindex",
+        "re-index",
+        "searches",
+        "searching"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the file type associated with a file extension",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.DefaultPrograms /page pageFileAssoc",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "associate",
+        "association",
+        "associations",
+        "extensions",
+        "extentions",
+        "type",
+        "filetype",
+        "open",
+        "with"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ]
+    ]
+  },
+  {
+    "Name": "Show hidden files and folders",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Options_RunDLL 7",
+    "Keywords": [
+      [
+        "folders",
+        "subfolders"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ]
+    ]
+  },
+  {
+    "Name": "Show or hide file extensions",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Options_RunDLL 7",
+    "Keywords": [
+      [
+        "associate",
+        "association",
+        "associations",
+        "extensions",
+        "extentions",
+        "type",
+        "filetype",
+        "open",
+        "with"
+      ],
+      [
+        "autohide",
+        "auto-hide",
+        "automatically",
+        "hide",
+        "make",
+        "invisible"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ]
+    ]
+  },
+  {
+    "Name": "Specify single- or double-click to open",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.FolderOptions",
+    "Keywords": [
+      [
+        "choice",
+        "chooses",
+        "choosing",
+        "chose",
+        "picked",
+        "picks",
+        "selected",
+        "selects"
+      ],
+      [
+        "lock",
+        "clicking",
+        "doubleclick",
+        "double-click",
+        "single-click"
+      ]
+    ]
+  },
+  {
+    "Name": "Preview, delete, show or hide fonts",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Fonts",
+    "Keywords": [
+      [
+        "faunt",
+        "fonts",
+        "type",
+        "truetype",
+        "type",
+        "opentype",
+        "fount"
+      ],
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "deinstall",
+        "uninstalled",
+        "uninstalling",
+        "uninstalls",
+        "unistall"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Font Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Fonts /page ::{93412589-74D4-4E4E-AD0E-E0CB621440FD}",
+    "Keywords": [
+      [
+        "faunt",
+        "fonts",
+        "type",
+        "truetype",
+        "type",
+        "opentype",
+        "fount"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "autohide",
+        "auto-hide",
+        "automatically",
+        "hide",
+        "make",
+        "invisible"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ]
+    ]
+  },
+  {
+    "Name": "View installed fonts",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Fonts",
+    "Keywords": [
+      [
+        "faunt",
+        "fonts",
+        "type",
+        "truetype",
+        "type",
+        "opentype",
+        "fount"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Private Character Editor",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\eudcedit.exe",
+    "Keywords": [
+      [
+        "eudcedit.exe",
+        "private",
+        "character",
+        "editor"
+      ]
+    ]
+  },
+  {
+    "Name": "Adjust commonly used mobility settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mblctr.exe /open",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "computer",
+        "top",
+        "laptop",
+        "mobile",
+        "pc",
+        "notebook",
+        "portable"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Adjust settings before giving a presentation",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\presentationsettings.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "pixels",
+        "reslution",
+        "resoltion",
+        "resolution",
+        "resolutoin",
+        "rezolution",
+        "size"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Block or allow pop-ups",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,2",
+    "Keywords": [
+      [
+        "banned",
+        "blocker",
+        "filter",
+        "nanny",
+        "prevent",
+        "restrict",
+        "stopper"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "ads",
+        "advertising",
+        "advertizing",
+        "adverts",
+        "adware",
+        "adwear",
+        "malware",
+        "ups",
+        "popupblocker",
+        "pop-upblocker",
+        "popups",
+        "pop-ups",
+        "popupstopper",
+        "spyware",
+        "spywear",
+        "unwanted",
+        "windows"
+      ],
+      [
+        "private",
+        "privacy",
+        "secrecy"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Block or allow third-party cookies",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,2",
+    "Keywords": [
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "banned",
+        "blocker",
+        "filter",
+        "nanny",
+        "prevent",
+        "restrict",
+        "stopper"
+      ],
+      [
+        "3rd",
+        "party",
+        "cookies",
+        "cooky",
+        "from",
+        "others",
+        "third-party",
+        "unwanted"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how web pages are displayed in tabs",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "browsers",
+        "browsing",
+        "web"
+      ],
+      [
+        "ie",
+        "internet",
+        "explorer"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "tabs",
+        "tabbed",
+        "browsing",
+        "quick"
+      ]
+    ]
+  },
+  {
+    "Name": "Change security settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,1",
+    "Keywords": [
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "banned",
+        "blocker",
+        "filter",
+        "nanny",
+        "prevent",
+        "restrict",
+        "stopper"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ]
+    ]
+  },
+  {
+    "Name": "Change temporary Internet file settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "3rd",
+        "party",
+        "cookies",
+        "cooky",
+        "from",
+        "others",
+        "third-party",
+        "unwanted"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "temp",
+        "cached",
+        "files",
+        "history",
+        "local",
+        "temorary",
+        "temporary",
+        "temperary",
+        "tmp",
+        "unnecessary",
+        "unneeded",
+        "useless",
+        "web"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the search provider in Internet Explorer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "by",
+        "defaults",
+        "defualt",
+        "standard"
+      ],
+      [
+        "provider",
+        "engine",
+        "searching"
+      ]
+    ]
+  },
+  {
+    "Name": "Change your homepage",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "page",
+        "homepage"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ]
+    ]
+  },
+  {
+    "Name": "Configure proxy server",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,4",
+    "Keywords": [
+      [
+        "server",
+        "web",
+        "winsock",
+        "socks",
+        "socket",
+        "dns",
+        "sas",
+        "winproxy",
+        "rpoxy",
+        "client",
+        "hosts",
+        "tmproxy",
+        "proxycfg"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Connect to the Internet",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "ms-availablenetworks:",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "wizard",
+        "wizzard"
+      ]
+    ]
+  },
+  {
+    "Name": "Delete browsing history",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "browsers",
+        "browsing",
+        "web"
+      ],
+      [
+        "autohide",
+        "auto-hide",
+        "automatically",
+        "hide",
+        "make",
+        "invisible"
+      ],
+      [
+        "ie",
+        "internet",
+        "explorer"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "temp",
+        "cached",
+        "files",
+        "history",
+        "local",
+        "temorary",
+        "temporary",
+        "temperary",
+        "tmp",
+        "unnecessary",
+        "unneeded",
+        "useless",
+        "web"
+      ]
+    ]
+  },
+  {
+    "Name": "Delete cookies or temporary files",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,0",
+    "Keywords": [
+      [
+        "3rd",
+        "party",
+        "cookies",
+        "cooky",
+        "from",
+        "others",
+        "third-party",
+        "unwanted"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "temp",
+        "cached",
+        "files",
+        "history",
+        "local",
+        "temorary",
+        "temporary",
+        "temperary",
+        "tmp",
+        "unnecessary",
+        "unneeded",
+        "useless",
+        "web"
+      ]
+    ]
+  },
+  {
+    "Name": "Enable or disable session cookies",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,2",
+    "Keywords": [
+      [
+        "3rd",
+        "party",
+        "cookies",
+        "cooky",
+        "from",
+        "others",
+        "third-party",
+        "unwanted"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage browser add-ons",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,5",
+    "Keywords": [
+      [
+        "activex",
+        "ons",
+        "add-ons",
+        "extension"
+      ],
+      [
+        "browsers",
+        "browsing",
+        "web"
+      ],
+      [
+        "add",
+        "new",
+        "installed",
+        "installing"
+      ],
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "deinstall",
+        "uninstalled",
+        "uninstalling",
+        "uninstalls",
+        "unistall"
+      ]
+    ]
+  },
+  {
+    "Name": "Tell if an RSS feed is available on a website",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,3",
+    "Keywords": [
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "rss",
+        "feed",
+        "aggregator",
+        "csrss"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn autocomplete in Internet Explorer on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,3",
+    "Keywords": [
+      [
+        "autocomplete",
+        "complete",
+        "completion",
+        "finish",
+        "autofinish",
+        "fill",
+        "autofill"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ]
+    ]
+  },
+  {
+    "Name": "Choose how you open links",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL inetcpl.cpl,,5",
+    "Keywords": [
+      [
+        "desktops",
+        "dekstops"
+      ],
+      [
+        "lanch",
+        "launches"
+      ],
+      [
+        "ie",
+        "internet",
+        "explorer"
+      ],
+      [
+        "browsers",
+        "browsing",
+        "web"
+      ],
+      [
+        "opens",
+        "opening",
+        "opened"
+      ],
+      [
+        "links"
+      ],
+      [
+        "tiles"
+      ],
+      [
+        "always",
+        "in"
+      ],
+      [
+        "let",
+        "decide"
+      ]
+    ]
+  },
+  {
+    "Name": "Change cursor blink rate",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Keyboard",
+    "Keywords": [
+      [
+        "blinking",
+        "blinkrate",
+        "flashing",
+        "rate"
+      ],
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ]
+    ]
+  },
+  {
+    "Name": "Check keyboard status",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Keyboard /page 1",
+    "Keywords": [
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ]
+    ]
+  },
+  {
+    "Name": "Change mouse settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse",
+    "Keywords": [
+      [
+        "butons",
+        "buttons"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "lock",
+        "clicking",
+        "doubleclick",
+        "double-click",
+        "single-click"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "flip",
+        "handed",
+        "hander",
+        "left-handed",
+        "left-hander",
+        "lefty",
+        "reverse",
+        "handed",
+        "right-handed",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how the mouse pointer looks",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse /page 1",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how the mouse pointer looks when it\u2019s moving",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse /page 2",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "move",
+        "moving",
+        "shadow",
+        "speed",
+        "tails"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ]
+    ]
+  },
+  {
+    "Name": "Change mouse click settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "lock",
+        "clicking",
+        "doubleclick",
+        "double-click",
+        "single-click"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change mouse click settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "lock",
+        "clicking",
+        "doubleclick",
+        "double-click",
+        "single-click"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change mouse wheel settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse /page 3",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "wheel",
+        "scrolling",
+        "scrollwheel",
+        "mousewheel"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the mouse pointer display or speed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse /page 2",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "move",
+        "moving",
+        "shadow",
+        "speed",
+        "tails"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ]
+    ]
+  },
+  {
+    "Name": "Customise the mouse buttons",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse",
+    "Keywords": [
+      [
+        "butons",
+        "buttons"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ],
+      [
+        "flip",
+        "handed",
+        "hander",
+        "left-handed",
+        "left-hander",
+        "lefty",
+        "reverse",
+        "handed",
+        "right-handed",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Make it easier to see the mouse pointer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Mouse /page 2",
+    "Keywords": [
+      [
+        "arrows",
+        "cursors",
+        "mouse",
+        "pointers"
+      ],
+      [
+        "finding",
+        "locate",
+        "locating",
+        "search",
+        "for",
+        "is",
+        "where's",
+        "the"
+      ],
+      [
+        "cannot",
+        "cant",
+        "find",
+        "can't",
+        "see",
+        "gone",
+        "hidden",
+        "invisible",
+        "missing",
+        "vanished",
+        "where",
+        "is"
+      ],
+      [
+        "mice",
+        "mouses",
+        "pointer"
+      ]
+    ]
+  },
+  {
+    "Name": "Get more features with a new edition of Windows",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\system32\\WindowsAnytimeUpgradeUI.exe",
+    "Keywords": [
+      [
+        "compare",
+        "comparison",
+        "side-by-side"
+      ],
+      [
+        "features",
+        "get",
+        "more",
+        "next",
+        "version",
+        "vista",
+        "home",
+        "business",
+        "premium",
+        "ultimate",
+        "starter"
+      ],
+      [
+        "vista",
+        "windows",
+        "windw",
+        "7"
+      ],
+      [
+        "release",
+        "version",
+        "edition"
+      ],
+      [
+        "centre",
+        "features",
+        "windows",
+        "anytime",
+        "upgrade",
+        "media",
+        "center",
+        "play",
+        "dvd",
+        "watch",
+        "tv",
+        "television",
+        "record"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up dialling rules",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PhoneAndModemOptions",
+    "Keywords": [
+      [
+        "calling",
+        "calls"
+      ],
+      [
+        "area",
+        "code",
+        "carrier",
+        "city",
+        "up",
+        "dialing",
+        "dialling",
+        "dialup",
+        "dial-up",
+        "pulse",
+        "tone",
+        "touchtone",
+        "touch-tone"
+      ],
+      [
+        "modem"
+      ],
+      [
+        "phone",
+        "line",
+        "telephone"
+      ],
+      [
+        "rules"
+      ]
+    ]
+  },
+  {
+    "Name": "Change battery settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "batteries",
+        "battery",
+        "life",
+        "conserve",
+        "energy",
+        "last",
+        "longer",
+        "management",
+        "plugged",
+        "in",
+        "supply",
+        "powersaver",
+        "preserve",
+        "save",
+        "mode",
+        "saving",
+        "unplugged",
+        "ups"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change power-saving settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "batteries",
+        "battery",
+        "life",
+        "conserve",
+        "energy",
+        "last",
+        "longer",
+        "management",
+        "plugged",
+        "in",
+        "supply",
+        "powersaver",
+        "preserve",
+        "save",
+        "mode",
+        "saving",
+        "unplugged",
+        "ups"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change what closing the lid does",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions /page pageGlobalSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "close",
+        "closing"
+      ],
+      [
+        "def",
+        "hearing",
+        "deaf",
+        "deafness",
+        "hard",
+        "of",
+        "problem",
+        "impaired",
+        "imparied"
+      ],
+      [
+        "cover",
+        "lid",
+        "top"
+      ],
+      [
+        "batteries",
+        "battery",
+        "life",
+        "conserve",
+        "energy",
+        "last",
+        "longer",
+        "management",
+        "plugged",
+        "in",
+        "supply",
+        "powersaver",
+        "preserve",
+        "save",
+        "mode",
+        "saving",
+        "unplugged",
+        "ups"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change what the power buttons do",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions /page pageGlobalSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "on-off",
+        "switch"
+      ],
+      [
+        "turn",
+        "hibernate",
+        "button",
+        "down",
+        "power-button",
+        "shutdown",
+        "shut-down",
+        "shuts",
+        "by",
+        "standby",
+        "stand-by",
+        "switches",
+        "turns",
+        "off"
+      ],
+      [
+        "batteries",
+        "battery",
+        "life",
+        "conserve",
+        "energy",
+        "last",
+        "longer",
+        "management",
+        "plugged",
+        "in",
+        "supply",
+        "powersaver",
+        "preserve",
+        "save",
+        "mode",
+        "saving",
+        "unplugged",
+        "ups"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change when the computer sleeps",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions /page pagePlanSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "batteries",
+        "battery",
+        "life",
+        "conserve",
+        "energy",
+        "last",
+        "longer",
+        "management",
+        "plugged",
+        "in",
+        "supply",
+        "powersaver",
+        "preserve",
+        "save",
+        "mode",
+        "saving",
+        "unplugged",
+        "ups"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "asleep",
+        "autowake",
+        "awaken",
+        "come",
+        "back",
+        "from",
+        "hibernates",
+        "hibernating",
+        "hibernation",
+        "restarts",
+        "resumes",
+        "sleeping",
+        "standby",
+        "up",
+        "wakeup",
+        "wake-up",
+        "waking"
+      ]
+    ]
+  },
+  {
+    "Name": "Choose when to turn off display",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions /page pagePlanSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "turn",
+        "hibernate",
+        "button",
+        "down",
+        "power-button",
+        "shutdown",
+        "shut-down",
+        "shuts",
+        "by",
+        "standby",
+        "stand-by",
+        "switches",
+        "turns",
+        "off"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Choose a power plan",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "plans",
+        "choose",
+        "select",
+        "power",
+        "scheme",
+        "balanced",
+        "saver",
+        "change"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Edit power plan",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.PowerOptions /page pagePlanSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "plans",
+        "choose",
+        "select",
+        "power",
+        "scheme",
+        "balanced",
+        "saver",
+        "change"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Change screen saver",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL desk.cpl,screensaver,@screensaver",
+    "Keywords": [
+      [
+        "savers",
+        "screan",
+        "screansavers",
+        "screeen",
+        "screeensavers",
+        "screen",
+        "screen-saver",
+        "screensavers",
+        "scren",
+        "screne",
+        "screnesavers",
+        "scrensavers",
+        "scrren",
+        "scrrensavers"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn screen saver on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL desk.cpl,screensaver,@screensaver",
+    "Keywords": [
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "savers",
+        "screan",
+        "screansavers",
+        "screeen",
+        "screeensavers",
+        "screen",
+        "screen-saver",
+        "screensavers",
+        "scren",
+        "screne",
+        "screnesavers",
+        "scrensavers",
+        "scrren",
+        "scrrensavers"
+      ]
+    ]
+  },
+  {
+    "Name": "Change date, time or number formats",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL intl.cpl",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "sterling",
+        "pence",
+        "cents",
+        "currency",
+        "dollars",
+        "euros",
+        "money",
+        "pounds",
+        "sign",
+        "symbol",
+        "won",
+        "yen",
+        "yuan"
+      ],
+      [
+        "show",
+        "displayed"
+      ],
+      [
+        "formated",
+        "formating",
+        "formatted",
+        "formatting"
+      ],
+      [
+        "m",
+        "centimeters",
+        "centimetres",
+        "cm",
+        "feet",
+        "foot",
+        "inches",
+        "kilometers",
+        "kilometres",
+        "kilos",
+        "km",
+        "lbs",
+        "measurements",
+        "meters",
+        "metres",
+        "miles",
+        "numbers",
+        "ounces",
+        "oz",
+        "pounds",
+        "weight",
+        "width"
+      ],
+      [
+        "countries",
+        "country",
+        "dev",
+        "region",
+        "language",
+        "localisation",
+        "localised",
+        "locality",
+        "localization",
+        "localized",
+        "1",
+        "2",
+        "3",
+        "code",
+        "regional",
+        "regions",
+        "locale"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ],
+      [
+        "alphabetise",
+        "alphabetize",
+        "order",
+        "sorting"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the way currency is displayed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL intl.cpl",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "sterling",
+        "pence",
+        "cents",
+        "currency",
+        "dollars",
+        "euros",
+        "money",
+        "pounds",
+        "sign",
+        "symbol",
+        "won",
+        "yen",
+        "yuan"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the way dates and lists are displayed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL intl.cpl",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the way measurements are displayed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL intl.cpl",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "m",
+        "centimeters",
+        "centimetres",
+        "cm",
+        "feet",
+        "foot",
+        "inches",
+        "kilometers",
+        "kilometres",
+        "kilos",
+        "km",
+        "lbs",
+        "measurements",
+        "meters",
+        "metres",
+        "miles",
+        "numbers",
+        "ounces",
+        "oz",
+        "pounds",
+        "weight",
+        "width"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the way time is displayed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL intl.cpl",
+    "Keywords": [
+      [
+        "appearance",
+        "out",
+        "layout",
+        "of",
+        "looks",
+        "way",
+        "displayed"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "ddmmyyyy",
+        "hour",
+        "12-hour",
+        "24-hour",
+        "clock",
+        "date",
+        "day",
+        "dd",
+        "display",
+        "formating",
+        "formatting",
+        "four",
+        "digit",
+        "long",
+        "mmddyyyy",
+        "month",
+        "properties",
+        "short",
+        "time",
+        "two",
+        "year",
+        "yyyy"
+      ]
+    ]
+  },
+  {
+    "Name": "Add a language",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Language",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "choice",
+        "chooses",
+        "choosing",
+        "chose",
+        "picked",
+        "picks",
+        "selected",
+        "selects"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "british",
+        "english",
+        "foreign",
+        "languages",
+        "french",
+        "german",
+        "hindi",
+        "international",
+        "japanese",
+        "korean",
+        "langpack",
+        "langs",
+        "languages",
+        "multilanguage",
+        "multi-language",
+        "pack",
+        "spanish",
+        "uk",
+        "usa"
+      ],
+      [
+        "dialogues",
+        "text",
+        "words",
+        "menus",
+        "dialogs",
+        "buttons",
+        "labels",
+        "writing",
+        "ui",
+        "language"
+      ],
+      [
+        "messages",
+        "mesages"
+      ]
+    ]
+  },
+  {
+    "Name": "Change input methods",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Language",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "letter",
+        "characters",
+        "chinese",
+        "hangul",
+        "japanese",
+        "kanji",
+        "korean",
+        "writing"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "input",
+        "methods",
+        "imes"
+      ],
+      [
+        "board",
+        "bord",
+        "keyboards",
+        "keyborads",
+        "keybord"
+      ],
+      [
+        "british",
+        "english",
+        "foreign",
+        "languages",
+        "french",
+        "german",
+        "hindi",
+        "international",
+        "japanese",
+        "korean",
+        "langpack",
+        "langs",
+        "languages",
+        "multilanguage",
+        "multi-language",
+        "pack",
+        "spanish",
+        "uk",
+        "usa"
+      ],
+      [
+        "layout",
+        "out"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Settings for Microsoft IME (Japanese)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imejp\\imjpset.exe",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "japanese"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft Pinyin SimpleFast Options",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imesc\\imscprop.exe /EXPRESS",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "pinyin",
+        "mspy"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft Pinyin SimpleFast Options",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imesc\\imscprop.exe /EXPRESS",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "pinyin",
+        "mspy"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft New Phonetic Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /NPH",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "phonetic"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft New Phonetic Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /NPH",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "phonetic"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft New Phonetic Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /NPH",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "phonetic"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft ChangJie Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /CJ",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "changjie"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft ChangJie Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /CJ",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "changjie"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft ChangJie Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /CJ",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "changjie"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft Quick Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /QK",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "quick"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft Quick Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /QK",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "quick"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft Quick Settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imetc\\imtcprop.exe /QK",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "settings",
+        "quick"
+      ]
+    ]
+  },
+  {
+    "Name": "Microsoft IME Register Word (Japanese)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\ime\\imejp\\imjpdct.exe",
+    "Keywords": [
+      [
+        "msime",
+        "ime",
+        "register",
+        "word",
+        "japanese"
+      ]
+    ]
+  },
+  {
+    "Name": "Change how Windows searches",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.IndexingOptions /page 2",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "finder",
+        "indexing",
+        "reindex",
+        "re-index",
+        "searches",
+        "searching"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "vista",
+        "windows",
+        "windw",
+        "7"
+      ]
+    ]
+  },
+  {
+    "Name": "View recent messages about your computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter",
+    "Keywords": [
+      [
+        "warning",
+        "report",
+        "alert",
+        "windows",
+        "crash",
+        "hang",
+        "balloon",
+        "reminder"
+      ],
+      [
+        "messages",
+        "mesages"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Review your computer's status and resolve issues",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter",
+    "Keywords": [
+      [
+        "healthy"
+      ],
+      [
+        "checking",
+        "look",
+        "for",
+        "scanning",
+        "verify"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "condition",
+        "running",
+        "state",
+        "status"
+      ],
+      [
+        "fix",
+        "repair",
+        "error",
+        "warning",
+        "alert",
+        "windows",
+        "crash",
+        "hang",
+        "troubleshoot",
+        "diagnose",
+        "reports",
+        "diagnostic",
+        "diagnosis",
+        "balloon",
+        "reminder",
+        "performance",
+        "maintenance",
+        "maintain",
+        "reinstall",
+        "recovery",
+        "restore",
+        "cpc",
+        "completepc",
+        "pc",
+        "system",
+        "antivirus",
+        "anti-virus",
+        "spyware",
+        "networking",
+        "connection",
+        "connectivity"
+      ],
+      [
+        "messages",
+        "mesages"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ],
+      [
+        "download",
+        "view",
+        "drivers",
+        "get",
+        "instructions",
+        "recommendations",
+        "messages"
+      ]
+    ]
+  },
+  {
+    "Name": "Change User Account Control settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\UserAccountControlSettings.exe",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "dialogues",
+        "credentials",
+        "elevations",
+        "LUA",
+        "prompts",
+        "prompting",
+        "security",
+        "warnings",
+        "UAC",
+        "administrator",
+        "rights",
+        "privileges",
+        "permissions",
+        "users",
+        "accounts",
+        "controls",
+        "administrater",
+        "dialogs",
+        "popups"
+      ]
+    ]
+  },
+  {
+    "Name": "View reliability history",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter /page pageReliabilityView",
+    "Keywords": [
+      [
+        "repair",
+        "problem",
+        "error",
+        "crash",
+        "hang"
+      ],
+      [
+        "reliability",
+        "monitor",
+        "problem",
+        "history",
+        "system",
+        "stability",
+        "index"
+      ]
+    ]
+  },
+  {
+    "Name": "Fix problems with your computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter",
+    "Keywords": [
+      [
+        "fix",
+        "repair",
+        "crash",
+        "hang",
+        "performance",
+        "maintenance",
+        "maintain",
+        "problems",
+        "reports",
+        "and"
+      ],
+      [
+        "re-instate",
+        "re-set",
+        "recovery",
+        "recover",
+        "reinstall",
+        "factory",
+        "re-image",
+        "reimage",
+        "re-install",
+        "repair",
+        "restore",
+        "reinstate",
+        "reset",
+        "wipe",
+        "rollback",
+        "fix",
+        "troubleshoot",
+        "pc",
+        "refresh",
+        "erase",
+        "format"
+      ],
+      [
+        "messages",
+        "mesages"
+      ]
+    ]
+  },
+  {
+    "Name": "View recommended actions to keep Windows running smoothly",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter",
+    "Keywords": [
+      [
+        "fix",
+        "repair",
+        "crash",
+        "hang",
+        "performance",
+        "maintenance",
+        "maintain",
+        "problems",
+        "reports",
+        "and"
+      ],
+      [
+        "messages",
+        "mesages"
+      ]
+    ]
+  },
+  {
+    "Name": "Check security status",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter",
+    "Keywords": [
+      [
+        "centre",
+        "security",
+        "center",
+        "firewall",
+        "malware",
+        "virus",
+        "warning",
+        "windows",
+        "crash",
+        "antivirus",
+        "anti-virus",
+        "spyware",
+        "worm",
+        "trojan"
+      ]
+    ]
+  },
+  {
+    "Name": "View all problem reports",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter /page pageProblems",
+    "Keywords": [
+      [
+        "reports",
+        "tell",
+        "microsoft",
+        "send",
+        "sent",
+        "clear",
+        "problems",
+        "delete",
+        "history",
+        "and",
+        "erase",
+        "view",
+        "all"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Automatic Maintenance settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.ActionCenter /page MaintenanceSettings",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Adjust system volume",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\sndvol.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "not",
+        "hear",
+        "can't",
+        "sound",
+        "volume",
+        "is",
+        "off",
+        "too",
+        "low"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ],
+      [
+        "audio",
+        "card",
+        "computer",
+        "external",
+        "internal",
+        "pc",
+        "speakers"
+      ],
+      [
+        "sound",
+        "louder",
+        "mute",
+        "noise",
+        "quiet",
+        "quite",
+        "soft",
+        "volume"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ]
+    ]
+  },
+  {
+    "Name": "Change sound card settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Sound",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "cards",
+        "soundcards"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ]
+    ]
+  },
+  {
+    "Name": "Change system sounds",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Sound /page 2",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "not",
+        "hear",
+        "can't",
+        "sound",
+        "volume",
+        "is",
+        "off",
+        "too",
+        "low"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage audio devices",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Sound",
+    "Keywords": [
+      [
+        "audio",
+        "balance",
+        "card",
+        "effect",
+        "encoding",
+        "jack",
+        "level",
+        "line",
+        "microphone",
+        "mono",
+        "multichannel",
+        "multi-channel",
+        "port",
+        "sound",
+        "speaker",
+        "stereo",
+        "subwoofer",
+        "surround"
+      ],
+      [
+        "in",
+        "line-in"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "midi",
+        "musical",
+        "instrument",
+        "digital",
+        "interface"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "audio",
+        "beeps",
+        "music",
+        "noises",
+        "schemes",
+        "sounds",
+        "tones",
+        "wav",
+        "sound",
+        "beep",
+        "noise"
+      ],
+      [
+        "used",
+        "using"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ]
+    ]
+  },
+  {
+    "Name": "Change text-to-speech settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL %windir%\\system32\\speech\\speechux\\sapi.cpl",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "text",
+        "to",
+        "speech",
+        "tts",
+        "voice",
+        "narrator"
+      ]
+    ]
+  },
+  {
+    "Name": "Print the speech reference card",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "http://go.microsoft.com/fwlink/?LinkId=619882",
+    "Keywords": [
+      [
+        "adapters",
+        "adaptor",
+        "cards"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ],
+      [
+        "card",
+        "help",
+        "instructions",
+        "paper",
+        "reference",
+        "sheet"
+      ],
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up a microphone",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%WINDIR%\\system32\\msdt.exe /id SpeechDiagnosticCalibrate /ep ControlPanel /skip true",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "external",
+        "headset",
+        "internal",
+        "jack",
+        "phone",
+        "microphones",
+        "mics",
+        "mikes"
+      ],
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ],
+      [
+        "used",
+        "using"
+      ]
+    ]
+  },
+  {
+    "Name": "Start speech recognition",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\speech\\common\\sapisvr.exe -SpeechUX",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ]
+    ]
+  },
+  {
+    "Name": "Take speech tutorials",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe %windir%\\system32\\speech\\speechux\\SpeechUX.dll,RunWizard Tutorial",
+    "Keywords": [
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ],
+      [
+        "teach",
+        "training",
+        "tutorial"
+      ],
+      [
+        "learn",
+        "lessons",
+        "teach",
+        "tutorial",
+        "example",
+        "training",
+        "wizard",
+        "to",
+        "use",
+        "how"
+      ]
+    ]
+  },
+  {
+    "Name": "Train the computer to recognise your voice",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe %windir%\\system32\\speech\\speechux\\SpeechUX.dll,RunWizard UserTraining",
+    "Keywords": [
+      [
+        "accuracy",
+        "accurately",
+        "precise",
+        "precision",
+        "correct",
+        "mistakes"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "best",
+        "better",
+        "easier",
+        "easy",
+        "enhance",
+        "improvement",
+        "make",
+        "more",
+        "most",
+        "optimal",
+        "optimise",
+        "optimize"
+      ],
+      [
+        "recognise",
+        "activated",
+        "commanding",
+        "dictate",
+        "dictation",
+        "recogination",
+        "recognition",
+        "recognize",
+        "recongition",
+        "reconition",
+        "speaking",
+        "speechrecognition",
+        "speech-recognition",
+        "talk",
+        "to",
+        "understand",
+        "voice"
+      ],
+      [
+        "teach",
+        "training",
+        "tutorial"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage offline files",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL %windir%\\system32\\cscui.dll",
+    "Keywords": [
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "line",
+        "offline",
+        "off-line",
+        "ofline"
+      ]
+    ]
+  },
+  {
+    "Name": "Encrypt your offline files",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL %windir%\\system32\\cscui.dll ,2",
+    "Keywords": [
+      [
+        "line",
+        "offline",
+        "off-line",
+        "ofline"
+      ],
+      [
+        "guard",
+        "protect",
+        "secure",
+        "preserve"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage disk space used by your offline files",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL %windir%\\system32\\cscui.dll ,1",
+    "Keywords": [
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "line",
+        "offline",
+        "off-line",
+        "ofline"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "store",
+        "space",
+        "cache",
+        "room"
+      ]
+    ]
+  },
+  {
+    "Name": "Adjust the appearance and performance of Windows",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesPerformance.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "optimise",
+        "crawl",
+        "degrade",
+        "faster",
+        "frozen",
+        "hanging",
+        "hung",
+        "improve",
+        "inactive",
+        "optimize",
+        "performance",
+        "quicker",
+        "sluggish",
+        "speed",
+        "thrashing",
+        "too",
+        "slow",
+        "unresponsive"
+      ],
+      [
+        "visuals",
+        "effects",
+        "drop",
+        "shadows",
+        "smooth",
+        "scrolling",
+        "slide",
+        "fade",
+        "sliding",
+        "fading"
+      ]
+    ]
+  },
+  {
+    "Name": "Allow remote access to your computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesRemote.exe",
+    "Keywords": [
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "access",
+        "control",
+        "RAS",
+        "acess",
+        "assistance",
+        "desktop",
+        "remotely",
+        "terminal",
+        "services",
+        "ts"
+      ],
+      [
+        "top",
+        "remote",
+        "desktop"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Allow Remote Assistance invitations to be sent from this computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesRemote.exe",
+    "Keywords": [
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "invitations",
+        "invite",
+        "inviting",
+        "send"
+      ],
+      [
+        "access",
+        "control",
+        "RAS",
+        "acess",
+        "assistance",
+        "desktop",
+        "remotely",
+        "terminal",
+        "services",
+        "ts"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ]
+    ]
+  },
+  {
+    "Name": "Invite someone to connect to your PC and help you, or offer to help someone else",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\system32\\msra.exe",
+    "Keywords": [
+      [
+        "access",
+        "control",
+        "RAS",
+        "acess",
+        "assistance",
+        "desktop",
+        "remotely",
+        "terminal",
+        "services",
+        "ts"
+      ],
+      [
+        "invitations",
+        "invite",
+        "inviting",
+        "send"
+      ]
+    ]
+  },
+  {
+    "Name": "Change workgroup name",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesComputerName.exe",
+    "Keywords": [
+      [
+        "connect",
+        "to",
+        "enter",
+        "join",
+        "plug",
+        "into"
+      ],
+      [
+        "names",
+        "rename",
+        "renaming"
+      ],
+      [
+        "group",
+        "workgroup"
+      ]
+    ]
+  },
+  {
+    "Name": "Check processor speed",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "checking",
+        "look",
+        "for",
+        "scanning",
+        "verify"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "486",
+        "agp",
+        "amd",
+        "bus",
+        "chip",
+        "clock",
+        "cpu",
+        "fast",
+        "intel",
+        "overclock",
+        "pentium",
+        "performance",
+        "processing",
+        "processor",
+        "ram",
+        "up",
+        "speedup"
+      ]
+    ]
+  },
+  {
+    "Name": "Configure advanced user profile properties",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe sysdm.cpl,EditUserProfiles",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Create a restore point",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesProtection.exe",
+    "Keywords": [
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "data",
+        "recovering",
+        "recovers",
+        "recovery"
+      ],
+      [
+        "points",
+        "wizard",
+        "system",
+        "protection",
+        "restores",
+        "systemrestores"
+      ]
+    ]
+  },
+  {
+    "Name": "Edit environment variables for your account",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe sysdm.cpl,EditEnvironmentVariables",
+    "Keywords": [
+      [
+        "environment",
+        "variables",
+        "path",
+        "envvar"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ]
+    ]
+  },
+  {
+    "Name": "Edit the system environment variables",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesAdvanced.exe",
+    "Keywords": [
+      [
+        "environment",
+        "variables",
+        "path",
+        "envvar"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ]
+    ]
+  },
+  {
+    "Name": "How to change the size of virtual memory",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "mshelp://windows/?id=89ca317f-649d-40a6-8934-e5707ee5c4b8",
+    "Keywords": [
+      [
+        "bigger",
+        "decrease",
+        "enlarge",
+        "increase",
+        "larger",
+        "resize",
+        "shape",
+        "short",
+        "shrink",
+        "size",
+        "skinny",
+        "smaller",
+        "taller",
+        "thin",
+        "too",
+        "wider",
+        "width"
+      ],
+      [
+        "memory",
+        "virtualmemory",
+        "pagefile",
+        "file"
+      ]
+    ]
+  },
+  {
+    "Name": "Join a domain",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesComputerName.exe",
+    "Keywords": [
+      [
+        "connect",
+        "to",
+        "enter",
+        "join",
+        "plug",
+        "into"
+      ],
+      [
+        "domain",
+        "domian"
+      ],
+      [
+        "server"
+      ]
+    ]
+  },
+  {
+    "Name": "Rename this computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesComputerName.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "names",
+        "rename",
+        "renaming"
+      ]
+    ]
+  },
+  {
+    "Name": "Create a recovery drive",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\RecoveryDrive.exe",
+    "Keywords": [
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "re-instate",
+        "re-set",
+        "recovery",
+        "recover",
+        "reinstall",
+        "factory",
+        "re-image",
+        "reimage",
+        "re-install",
+        "repair",
+        "restore",
+        "reinstate",
+        "reset",
+        "wipe",
+        "rollback",
+        "fix",
+        "troubleshoot",
+        "pc",
+        "refresh",
+        "erase",
+        "format"
+      ]
+    ]
+  },
+  {
+    "Name": "See the name of this computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "names",
+        "rename",
+        "renaming"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Select users who can use remote desktop",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesRemote.exe",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "access",
+        "permissions",
+        "priveleges",
+        "priviledges",
+        "privileges",
+        "rights"
+      ],
+      [
+        "access",
+        "control",
+        "RAS",
+        "acess",
+        "assistance",
+        "desktop",
+        "remotely",
+        "terminal",
+        "services",
+        "ts"
+      ],
+      [
+        "top",
+        "remote",
+        "desktop"
+      ]
+    ]
+  },
+  {
+    "Name": "Show how much RAM is on this computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "amount",
+        "of",
+        "many",
+        "much",
+        "howmuch"
+      ],
+      [
+        "gigabytes",
+        "gigs",
+        "megabytes",
+        "megs",
+        "memory",
+        "ram"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Show which domain your computer is on",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "domain",
+        "domian"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Show which operating system your computer is running",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "operating",
+        "system",
+        "os"
+      ],
+      [
+        "release",
+        "version",
+        "edition"
+      ],
+      [
+        "what",
+        "which"
+      ]
+    ]
+  },
+  {
+    "Name": "Show which workgroup this computer is on",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "group",
+        "workgroup"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "View advanced system settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\SystemPropertiesAdvanced.exe",
+    "Keywords": [
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ]
+    ]
+  },
+  {
+    "Name": "View basic information about your computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.System",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "gigabytes",
+        "gigs",
+        "megabytes",
+        "megs",
+        "memory",
+        "ram"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "Task Manager",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\taskmgr.exe /6",
+    "Keywords": [
+      [
+        "proceses",
+        "processes"
+      ],
+      [
+        "task manager",
+        "mgr",
+        "manager",
+        "taskmgr",
+        "view",
+        "task",
+        "application",
+        "taskman",
+        "end task",
+        "close"
+      ]
+    ]
+  },
+  {
+    "Name": "View system resource usage in Task Manager",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\taskmgr.exe /6",
+    "Keywords": [
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "network",
+        "connections",
+        "netwerk",
+        "conection"
+      ],
+      [
+        "486",
+        "agp",
+        "amd",
+        "bus",
+        "chip",
+        "clock",
+        "cpu",
+        "fast",
+        "intel",
+        "overclock",
+        "pentium",
+        "performance",
+        "processing",
+        "processor",
+        "ram",
+        "up",
+        "speedup"
+      ],
+      [
+        "memory",
+        "virtualmemory",
+        "pagefile",
+        "file"
+      ]
+    ]
+  },
+  {
+    "Name": "See which processes start up automatically when you start Windows",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\taskmgr.exe /6 /Startup",
+    "Keywords": [
+      [
+        "start-up",
+        "items",
+        "up",
+        "startup",
+        "programs"
+      ]
+    ]
+  },
+  {
+    "Name": "Auto-hide the taskbar",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Taskbar",
+    "Keywords": [
+      [
+        "flicks",
+        "gestures",
+        "flik",
+        "filcks",
+        "penflick"
+      ],
+      [
+        "autohide",
+        "auto-hide",
+        "automatically",
+        "hide",
+        "make",
+        "invisible"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "icons",
+        "area",
+        "sgtray.exe",
+        "start",
+        "tray",
+        "systemtray",
+        "systray",
+        "task",
+        "toolbar",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Navigation properties",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Options_RunDLL 8",
+    "Keywords": [
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "sign-in",
+        "applications view",
+        "navigation",
+        "desktop",
+        "mouse",
+        "start",
+        "corner",
+        "corners",
+        "background",
+        "windows logo key",
+        "windows key",
+        "win",
+        "winkey",
+        "sign in",
+        "signin",
+        "apps view",
+        "boot",
+        "to",
+        "charm",
+        "charms",
+        "powershell",
+        "command prompt"
+      ]
+    ]
+  },
+  {
+    "Name": "Customise the taskbar",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Taskbar",
+    "Keywords": [
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "icons",
+        "area",
+        "sgtray.exe",
+        "start",
+        "tray",
+        "systemtray",
+        "systray",
+        "task",
+        "toolbar",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Group similar windows on the taskbar",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Taskbar",
+    "Keywords": [
+      [
+        "grouping"
+      ],
+      [
+        "icons",
+        "area",
+        "sgtray.exe",
+        "start",
+        "tray",
+        "systemtray",
+        "systray",
+        "task",
+        "toolbar",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars"
+      ],
+      [
+        "vista",
+        "windows",
+        "windw",
+        "7"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Lock or unlock the taskbar",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Taskbar",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "icons",
+        "area",
+        "sgtray.exe",
+        "start",
+        "tray",
+        "systemtray",
+        "systray",
+        "task",
+        "toolbar",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars"
+      ],
+      [
+        "release",
+        "version",
+        "edition"
+      ],
+      [
+        "what",
+        "which"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "What's happened to the Quick Launch toolbar?",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "mshelp://windows/?id=329cf1bc-0f32-41ba-b717-362880a7f6df",
+    "Keywords": [
+      [
+        "icons",
+        "area",
+        "sgtray.exe",
+        "start",
+        "tray",
+        "systemtray",
+        "systray",
+        "task",
+        "toolbar",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars"
+      ],
+      [
+        "launch",
+        "quicklaunch",
+        "quiklaunch",
+        "tray",
+        "taskbar",
+        "task-bar",
+        "bars",
+        "toolbars",
+        "pin"
+      ],
+      [
+        "notifications",
+        "notifying",
+        "notified"
+      ]
+    ]
+  },
+  {
+    "Name": "Add or remove user accounts",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts /page pageAdminTasks",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "added",
+        "adding",
+        "addon",
+        "add-on",
+        "adds"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "users"
+      ]
+    ]
+  },
+  {
+    "Name": "Change account type",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\netplwiz.exe",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "names",
+        "rename",
+        "renaming"
+      ],
+      [
+        "users"
+      ]
+    ]
+  },
+  {
+    "Name": "Change account type",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts /page pageAdminTasks",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "names",
+        "rename",
+        "renaming"
+      ],
+      [
+        "users"
+      ]
+    ]
+  },
+  {
+    "Name": "Create a password reset disk",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe keymgr.dll,PRShowSaveWizardExW",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "can't",
+        "remember",
+        "don't",
+        "forget",
+        "forgotten",
+        "lost"
+      ],
+      [
+        "word",
+        "pass-word",
+        "passwords",
+        "passwork",
+        "passwrod",
+        "pasword",
+        "paswrod"
+      ]
+    ]
+  },
+  {
+    "Name": "Create an account",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts /page pageAdminTasks",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ]
+    ]
+  },
+  {
+    "Name": "Create standard user account",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts /page pageAdminTasks",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ]
+    ]
+  },
+  {
+    "Name": "Edit local users and groups",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\lusrmgr.msc",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ]
+    ]
+  },
+  {
+    "Name": "Give administrative rights to a domain user",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\netplwiz.exe",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "administrator",
+        "admins"
+      ],
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "domain",
+        "domian"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "access",
+        "permissions",
+        "priveleges",
+        "priviledges",
+        "privileges",
+        "rights"
+      ]
+    ]
+  },
+  {
+    "Name": "Give other users access to this computer",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\netplwiz.exe",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "access",
+        "permissions",
+        "priveleges",
+        "priviledges",
+        "privileges",
+        "rights"
+      ]
+    ]
+  },
+  {
+    "Name": "How to change your Windows password",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "mshelp://windows/?id=5c07e067-286d-4b8d-b342-431306e696aa",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "names",
+        "rename",
+        "renaming"
+      ],
+      [
+        "word",
+        "pass-word",
+        "passwords",
+        "passwork",
+        "passwrod",
+        "pasword",
+        "paswrod"
+      ]
+    ]
+  },
+  {
+    "Name": "Make changes to accounts",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts /page pageAdminTasks",
+    "Keywords": [
+      [
+        "accounts",
+        "alias",
+        "login",
+        "useraccount",
+        "useracount",
+        "users"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "access",
+        "permissions",
+        "priveleges",
+        "priviledges",
+        "privileges",
+        "rights"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage file encryption certificates",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rekeywiz.exe",
+    "Keywords": [
+      [
+        "certificates",
+        "keys",
+        "signatures",
+        "signed"
+      ],
+      [
+        "guard",
+        "protect",
+        "secure",
+        "preserve"
+      ],
+      [
+        "files"
+      ],
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage user certificates",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\mmc.exe %windir%\\system32\\certmgr.msc",
+    "Keywords": [
+      [
+        "certificate",
+        "key"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage network passwords",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.CredentialManager /page ?SelectedVault=CredmanVault",
+    "Keywords": [
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "word",
+        "pass-word",
+        "passwords",
+        "passwork",
+        "passwrod",
+        "pasword",
+        "paswrod"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ]
+    ]
+  },
+  {
+    "Name": "Reset Security Policies",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.UserAccounts",
+    "Keywords": [
+      [
+        "policies",
+        "policys"
+      ],
+      [
+        "Reset",
+        "Security",
+        "Exchange",
+        "ActiveSync"
+      ]
+    ]
+  },
+  {
+    "Name": "Allow an app through Windows Firewall",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsFirewall /page PageConfigureApps",
+    "Keywords": [
+      [
+        "allowed",
+        "let",
+        "through",
+        "permitted"
+      ],
+      [
+        "ecxeption",
+        "exception",
+        "exeption"
+      ],
+      [
+        "virus",
+        "builtin",
+        "built-in",
+        "fire-wall",
+        "firewalled",
+        "firwall",
+        "frewall",
+        "ifc",
+        "protection",
+        "walled"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "file",
+        "applets",
+        "applications",
+        "apps",
+        "aps",
+        "files",
+        "programmes",
+        "programs",
+        "softare",
+        "softwares",
+        "sofware",
+        "sotfware",
+        "windos",
+        "windows"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Check firewall status",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsFirewall",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "virus",
+        "builtin",
+        "built-in",
+        "fire-wall",
+        "firewalled",
+        "firwall",
+        "frewall",
+        "ifc",
+        "protection",
+        "walled"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage BitLocker",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.BitLockerDriveEncryption",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "locker",
+        "bitlocker",
+        "cryptology",
+        "decrypt",
+        "encode",
+        "encryption",
+        "device encryption"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "guard",
+        "protect",
+        "secure",
+        "preserve"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ]
+    ]
+  },
+  {
+    "Name": "Back up your recovery key",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.BitLockerDriveEncryption",
+    "Keywords": [
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "locker",
+        "bitlocker",
+        "cryptology",
+        "decrypt",
+        "encode",
+        "encryption",
+        "device encryption"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "guard",
+        "protect",
+        "secure",
+        "preserve"
+      ],
+      [
+        "restricted",
+        "safety",
+        "secure",
+        "securing",
+        "security",
+        "sites",
+        "trusted",
+        "trusting"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage Storage Spaces",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.StorageSpaces",
+    "Keywords": [
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "data",
+        "recovering",
+        "recovers",
+        "recovery"
+      ],
+      [
+        "disc",
+        "disks",
+        "drive"
+      ],
+      [
+        "storage"
+      ],
+      [
+        "spaces",
+        "storage-spaces",
+        "mirror",
+        "mirror-space",
+        "resilient",
+        "resilient-space"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage Work Folders",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WorkFolders",
+    "Keywords": [
+      [
+        "files"
+      ],
+      [
+        "line",
+        "offline",
+        "off-line",
+        "ofline"
+      ],
+      [
+        "folders",
+        "subfolders"
+      ],
+      [
+        "sync-centre",
+        "synchronise",
+        "work",
+        "work-folders",
+        "work-files",
+        "company-folders",
+        "company-files",
+        "sync-center",
+        "synchronize"
+      ]
+    ]
+  },
+  {
+    "Name": "Set flicks to perform certain tasks",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @0,flicks",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "flicks",
+        "gestures",
+        "flik",
+        "filcks",
+        "penflick"
+      ],
+      [
+        "hand-writing",
+        "handwriting",
+        "write",
+        "pen",
+        "stylus",
+        "handrighting",
+        "hand-righting",
+        "penmanship",
+        "calligraphy"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change tablet pen settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @0,pen",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "hand-writing",
+        "handwriting",
+        "write",
+        "pen",
+        "stylus",
+        "handrighting",
+        "hand-righting",
+        "penmanship",
+        "calligraphy"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Turn flicks on or off",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @0,flicks",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "flicks",
+        "gestures",
+        "flik",
+        "filcks",
+        "penflick"
+      ],
+      [
+        "hand-writing",
+        "handwriting",
+        "write",
+        "pen",
+        "stylus",
+        "handrighting",
+        "hand-righting",
+        "penmanship",
+        "calligraphy"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Change touch input settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @0,touch",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "touch",
+        "pointer",
+        "finger",
+        "pointing",
+        "cursor",
+        "mouse"
+      ],
+      [
+        "touch"
+      ]
+    ]
+  },
+  {
+    "Name": "Change multi-touch gesture settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @0,touch",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "touch",
+        "pointer",
+        "finger",
+        "pointing",
+        "cursor",
+        "mouse"
+      ],
+      [
+        "touch"
+      ]
+    ]
+  },
+  {
+    "Name": "Calibrate the screen for pen or touch input",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @1,general",
+    "Keywords": [
+      [
+        "accuracy",
+        "accurately",
+        "precise",
+        "precision",
+        "correct",
+        "mistakes"
+      ],
+      [
+        "calibrate",
+        "calibration"
+      ],
+      [
+        "monitors",
+        "screens"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ],
+      [
+        "pen"
+      ],
+      [
+        "touch"
+      ]
+    ]
+  },
+  {
+    "Name": "Choose the order of how your screen rotates",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @1,display",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "monitors",
+        "screens"
+      ],
+      [
+        "angle",
+        "landscape",
+        "orientation",
+        "portrait",
+        "rotate",
+        "rotation"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ]
+    ]
+  },
+  {
+    "Name": "Set tablet buttons to perform certain tasks",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @1,buttons",
+    "Keywords": [
+      [
+        "butons",
+        "buttons"
+      ],
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "customising",
+        "customisation",
+        "customises",
+        "customization",
+        "customizes",
+        "customizing",
+        "personalisation",
+        "personalise",
+        "personalization",
+        "personalize"
+      ],
+      [
+        "tablets",
+        "pc"
+      ]
+    ]
+  },
+  {
+    "Name": "Specify which hand you write with",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL TabletPC.cpl @1,other",
+    "Keywords": [
+      [
+        "hand-writing",
+        "handwriting",
+        "write",
+        "pen",
+        "stylus",
+        "handrighting",
+        "hand-righting",
+        "penmanship",
+        "calligraphy"
+      ],
+      [
+        "flip",
+        "handed",
+        "hander",
+        "left-handed",
+        "left-hander",
+        "lefty",
+        "reverse",
+        "handed",
+        "right-handed",
+        "switch"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Send or receive a file",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\rundll32.exe shell32.dll,Control_RunDLL irprops.cpl",
+    "Keywords": [
+      [
+        "infrared",
+        "infra-red",
+        "wireless"
+      ],
+      [
+        "beam",
+        "send",
+        "transmit"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Windows SideShow-compatible device settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsSideShow /page pageChangeSettingsDeviceSelector",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "ware",
+        "hardware-general"
+      ],
+      [
+        "side-show",
+        "auxiliary",
+        "display",
+        "show",
+        "sideshow"
+      ],
+      [
+        "change",
+        "settings"
+      ],
+      [
+        "gadgets",
+        "widgets"
+      ]
+    ]
+  },
+  {
+    "Name": "Change the order of Windows SideShow gadgets",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsSideShow /page pageReorderGadgetsDeviceSelector",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "gadgets",
+        "widgets"
+      ],
+      [
+        "organise",
+        "organising",
+        "arrange",
+        "arranging",
+        "ordering",
+        "organize",
+        "organizing",
+        "reorder"
+      ],
+      [
+        "side-show",
+        "auxiliary",
+        "display",
+        "show",
+        "sideshow"
+      ],
+      [
+        "alphabetise",
+        "alphabetize",
+        "order",
+        "sorting"
+      ]
+    ]
+  },
+  {
+    "Name": "Change Windows SideShow settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsSideShow",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "gadgets",
+        "widgets"
+      ],
+      [
+        "deactivate",
+        "cancel",
+        "deactivates",
+        "delete",
+        "deleting",
+        "disable",
+        "disallow",
+        "exit",
+        "get",
+        "rid",
+        "of",
+        "prevent",
+        "remove",
+        "removing",
+        "shut",
+        "down",
+        "off",
+        "stop",
+        "turn",
+        "turnoff"
+      ],
+      [
+        "side-show",
+        "auxiliary",
+        "display",
+        "show",
+        "sideshow"
+      ]
+    ]
+  },
+  {
+    "Name": "Change PC wake-up settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.WindowsSideShow /page pageAutoWake",
+    "Keywords": [
+      [
+        "automated",
+        "automatically"
+      ],
+      [
+        "laptop",
+        "compuer",
+        "machine",
+        "my",
+        "computer",
+        "pc",
+        "personal",
+        "system"
+      ],
+      [
+        "side-show",
+        "auxiliary",
+        "display",
+        "show",
+        "sideshow"
+      ],
+      [
+        "auto",
+        "out",
+        "period",
+        "timeout",
+        "timer",
+        "timing"
+      ],
+      [
+        "asleep",
+        "autowake",
+        "awaken",
+        "come",
+        "back",
+        "from",
+        "hibernates",
+        "hibernating",
+        "hibernation",
+        "restarts",
+        "resumes",
+        "sleeping",
+        "standby",
+        "up",
+        "wakeup",
+        "wake-up",
+        "waking"
+      ]
+    ]
+  },
+  {
+    "Name": "Calibrate display colour",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\dccw.exe",
+    "Keywords": [
+      [
+        "adjust",
+        "ajust",
+        "alter",
+        "change",
+        "edit",
+        "modify",
+        "replace",
+        "reset",
+        "set",
+        "switch"
+      ],
+      [
+        "crt",
+        "displays",
+        "monitors",
+        "screeens",
+        "screens"
+      ],
+      [
+        "adapters",
+        "adaptor",
+        "cards"
+      ],
+      [
+        "calibrate",
+        "calibration"
+      ],
+      [
+        "brightness",
+        "contrast",
+        "hi-contrast",
+        "high-contrast"
+      ],
+      [
+        "troubleshooting",
+        "history",
+        "problem"
+      ]
+    ]
+  },
+  {
+    "Name": "Adjust ClearType text",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\cttune.exe",
+    "Keywords": [
+      [
+        "faunt",
+        "fonts",
+        "type",
+        "truetype",
+        "type",
+        "opentype",
+        "fount"
+      ],
+      [
+        "dots",
+        "per",
+        "inch",
+        "dpi",
+        "pixels",
+        "high"
+      ],
+      [
+        "pixels",
+        "reslution",
+        "resoltion",
+        "resolution",
+        "resolutoin",
+        "rezolution",
+        "size"
+      ],
+      [
+        "wizard",
+        "wizzard"
+      ],
+      [
+        "personalise",
+        "personalisation",
+        "personalize",
+        "personalization"
+      ],
+      [
+        "type",
+        "cleartype",
+        "tuning",
+        "tuner",
+        "settings",
+        "contrast",
+        "gamma",
+        "text",
+        "aliasing",
+        "anti-aliasing",
+        "filtering",
+        "blurry",
+        "fuzzy"
+      ],
+      [
+        "typography",
+        "reading",
+        "readability",
+        "easier",
+        "to",
+        "easy",
+        "font",
+        "clarity",
+        "color",
+        "colour",
+        "enable",
+        "cleartype",
+        "tweak",
+        "typeface",
+        "text",
+        "size",
+        "ppi",
+        "legible",
+        "legibility"
+      ]
+    ]
+  },
+  {
+    "Name": "Connect to a network",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "ms-availablenetworks:",
+    "Keywords": [
+      [
+        "connect",
+        "to",
+        "enter",
+        "join",
+        "plug",
+        "into"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "802.1x",
+        "wireless",
+        "wire-less"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "wireless",
+        "LAN",
+        "wifi",
+        "Wi-Fi",
+        "WLAN"
+      ],
+      [
+        "aeroplane",
+        "all",
+        "wireless",
+        "on",
+        "off",
+        "plane",
+        "flight",
+        "radio",
+        "airplane",
+        "connection"
+      ],
+      [
+        "DA",
+        "direct",
+        "access",
+        "directaccess"
+      ],
+      [
+        "mobile phone",
+        "provider",
+        "mobile",
+        "broadband",
+        "2G",
+        "2.5G",
+        "3G",
+        "3.5G",
+        "4G",
+        "LTE",
+        "CDMA",
+        "GSM",
+        "wireless",
+        "cellphone",
+        "mbb",
+        "telco",
+        "carrier"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up a connection or network",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\xwizard.exe RunWizard {7071ECE0-663B-4bc1-A1FA-B97F3B917C55}",
+    "Keywords": [
+      [
+        "tooth",
+        "bluetooth",
+        "blutooth"
+      ],
+      [
+        "connect",
+        "to",
+        "enter",
+        "join",
+        "plug",
+        "into"
+      ],
+      [
+        "infrared",
+        "infra-red",
+        "wireless"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "802.1x",
+        "wireless",
+        "wire-less"
+      ]
+    ]
+  },
+  {
+    "Name": "Identify and repair network problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\Rundll32.exe ndfapi,NdfRunDllDiagnoseIncident",
+    "Keywords": [
+      [
+        "broken",
+        "doesn't",
+        "not",
+        "working",
+        "problems",
+        "won't"
+      ],
+      [
+        "diagnose",
+        "diagnostics",
+        "diagnosis",
+        "find",
+        "problems",
+        "analyse",
+        "analyze",
+        "analysis",
+        "troubleshooter",
+        "errors"
+      ],
+      [
+        "from",
+        "the",
+        "web",
+        "inet",
+        "internet",
+        "intrnet",
+        "net",
+        "online",
+        "on-line",
+        "sites",
+        "pages",
+        "webpages",
+        "websites",
+        "world",
+        "wide",
+        "www"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "corrects",
+        "fixes",
+        "repairs"
+      ],
+      [
+        "internet",
+        "wireless",
+        "ethernet",
+        "packet",
+        "dhcp",
+        "tcp/ip",
+        "protocol",
+        "nic",
+        "cable",
+        "certificate"
+      ],
+      [
+        "wireless",
+        "LAN",
+        "wifi",
+        "Wi-Fi",
+        "WLAN"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage advanced sharing settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.NetworkAndSharingCenter /page Advanced",
+    "Keywords": [
+      [
+        "sharing",
+        "shared",
+        "files",
+        "network",
+        "folder",
+        "target"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up a dial-up connection",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\xwizard.exe RunWizard {7071EC71-663B-4bc1-A1FA-B97F3B917C55}",
+    "Keywords": [
+      [
+        "area",
+        "code",
+        "carrier",
+        "city",
+        "up",
+        "dialing",
+        "dialling",
+        "dialup",
+        "dial-up",
+        "pulse",
+        "tone",
+        "touchtone",
+        "touch-tone"
+      ],
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "modem"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up a virtual private network (VPN) connection",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\xwizard.exe RunWizard {7071EC75-663B-4bc1-A1FA-B97F3B917C55}",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "virtual",
+        "private",
+        "network",
+        "vpn",
+        "workplace"
+      ]
+    ]
+  },
+  {
+    "Name": "Set up a broadband connection",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\xwizard.exe RunWizard {C03E8585-781E-49a1-8190-CE902D0B2CE7}",
+    "Keywords": [
+      [
+        "pppoe",
+        "broadband"
+      ],
+      [
+        "add",
+        "create",
+        "make",
+        "new"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ]
+    ]
+  },
+  {
+    "Name": "View network computers and devices",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "shell:::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}",
+    "Keywords": [
+      [
+        "adapters",
+        "adaptor",
+        "cards"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ]
+    ]
+  },
+  {
+    "Name": "View network connections",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\3\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}",
+    "Keywords": [
+      [
+        "adapters",
+        "adaptor",
+        "cards"
+      ],
+      [
+        "internet",
+        "protocol",
+        "ip",
+        "addresses",
+        "v6",
+        "version",
+        "6",
+        "IP6",
+        "IPv6",
+        "tcp/ip",
+        "tcp\\ip",
+        "tcpip"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ],
+      [
+        "internet",
+        "wireless",
+        "ethernet",
+        "packet",
+        "dhcp",
+        "tcp/ip",
+        "protocol",
+        "nic",
+        "cable",
+        "certificate"
+      ],
+      [
+        "virtual",
+        "private",
+        "network",
+        "vpn",
+        "workplace"
+      ]
+    ]
+  },
+  {
+    "Name": "View network status and tasks",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.NetworkAndSharingCenter",
+    "Keywords": [
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "automatically",
+        "autoshow",
+        "auto-show",
+        "make",
+        "visible",
+        "see",
+        "show",
+        "unlock",
+        "view"
+      ],
+      [
+        "condition",
+        "running",
+        "state",
+        "status"
+      ],
+      [
+        "check",
+        "list",
+        "see",
+        "show",
+        "viewing"
+      ],
+      [
+        "locations",
+        "networks"
+      ]
+    ]
+  },
+  {
+    "Name": "Media streaming options",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.NetworkAndSharingCenter /page ShareMedia",
+    "Keywords": [
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "sharing",
+        "shared",
+        "files",
+        "network",
+        "folder",
+        "target"
+      ],
+      [
+        "stream",
+        "media",
+        "library",
+        "options",
+        "with",
+        "to",
+        "mediasharing",
+        "mediastreaming",
+        "sharemedia",
+        "internetsharing"
+      ]
+    ]
+  },
+  {
+    "Name": "Access RemoteApp and desktops",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\xwizard.exe RunWizard {7940ACF8-60BA-4213-A7C3-F3B400EE266D}",
+    "Keywords": [
+      [
+        "activate",
+        "add",
+        "begin",
+        "enable",
+        "intsall",
+        "invoke",
+        "make",
+        "up",
+        "setting",
+        "setup",
+        "start",
+        "on",
+        "turnon",
+        "unlock"
+      ],
+      [
+        "set-up",
+        "confg",
+        "configuration",
+        "configure",
+        "define",
+        "management",
+        "options",
+        "personalise",
+        "personalize",
+        "up",
+        "settings",
+        "setup"
+      ],
+      [
+        "RemoteApp",
+        "Desktop",
+        "RemoteDesktop",
+        "Connection",
+        "work"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Troubleshooting",
+    "Keywords": [
+      [
+        "troubleshoot",
+        "shoot",
+        "troubleshooter",
+        "trubleshoot",
+        "help",
+        "solution"
+      ],
+      [
+        "diagnose",
+        "diagnostics",
+        "diagnosis",
+        "find",
+        "problems",
+        "analyse",
+        "analyze",
+        "analysis",
+        "troubleshooter",
+        "errors"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Troubleshooting",
+    "Keywords": [
+      [
+        "troubleshoot",
+        "shoot",
+        "troubleshooter",
+        "trubleshoot",
+        "help",
+        "solution"
+      ],
+      [
+        "diagnose",
+        "diagnostics",
+        "diagnosis",
+        "find",
+        "problems",
+        "analyse",
+        "analyze",
+        "analysis",
+        "troubleshooter",
+        "errors"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix audio playback problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id AudioPlaybackDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "Playing",
+        "sound",
+        "volume",
+        "audible",
+        "speaker",
+        "headphone",
+        "stereo",
+        "listen",
+        "hear",
+        "output",
+        "MP3",
+        "player"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix audio recording problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id AudioRecordingDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "Capture",
+        "sample",
+        "mix",
+        "level",
+        "input",
+        "sound",
+        "audible",
+        "volume",
+        "stereo",
+        "tape",
+        "microphone",
+        "mike"
+      ]
+    ]
+  },
+  {
+    "Name": "Perform recommended maintenance tasks automatically",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id MaintenanceDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "optimise",
+        "maintain",
+        "defrag",
+        "optimize",
+        "performance"
+      ],
+      [
+        "operating",
+        "system",
+        "os"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix networking and connection problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id NetworkDiagnosticsWeb -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "sharing",
+        "shared",
+        "files",
+        "network",
+        "folder",
+        "target"
+      ],
+      [
+        "internet",
+        "wireless",
+        "ethernet",
+        "packet",
+        "dhcp",
+        "tcp/ip",
+        "protocol",
+        "nic",
+        "cable",
+        "certificate"
+      ],
+      [
+        "wireless",
+        "LAN",
+        "wifi",
+        "Wi-Fi",
+        "WLAN"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix printing problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id PrinterDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "print",
+        "paper",
+        "ink",
+        "toner",
+        "laser",
+        "bubble",
+        "jet",
+        "cartridge"
+      ],
+      [
+        "out",
+        "printers",
+        "printing",
+        "printner",
+        "printout",
+        "print-out",
+        "pritner"
+      ]
+    ]
+  },
+  {
+    "Name": "Troubleshooting History",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.Troubleshooting /page HistoryPage",
+    "Keywords": [
+      [
+        "troubleshooting",
+        "history",
+        "problem"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix problems with Windows Search",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id SearchDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "finder",
+        "indexing",
+        "reindex",
+        "re-index",
+        "searches",
+        "searching"
+      ]
+    ]
+  },
+  {
+    "Name": "Record steps to reproduce a problem",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\psr.exe",
+    "Keywords": [
+      [
+        "recorder",
+        "screen",
+        "problem",
+        "capture",
+        "snipping",
+        "psr"
+      ],
+      [
+        "reproduce"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix keyboard problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id KeyboardDiagnostic -ep ControlPanelSearch",
+    "Keywords": [
+      [
+        "input method editor",
+        "asian input",
+        "japanese input",
+        "ime",
+        "keyboard",
+        "input"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix bluescreen problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id BlueScreenDiagnostic -ep CortanaBluescreenSearch",
+    "Keywords": [
+      [
+        "blueScreen",
+        "bluescreen issues",
+        "bluescreen",
+        "bad driver",
+        "drivers",
+        "blue screen",
+        "bug check"
+      ]
+    ]
+  },
+  {
+    "Name": "Find and fix windows update problems",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\msdt.exe -id windowsupdatediagnostic -ep CortanaWUSearch",
+    "Keywords": [
+      [
+        "Can't install update",
+        "Windows Update",
+        "Cannot update",
+        "issues with Windows Update",
+        "Windows Update Issues",
+        "WU",
+        "Update fails",
+        "Cant install update",
+        "Windows update error",
+        "WU error"
+      ]
+    ]
+  },
+  {
+    "Name": "Change location settings",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.LocationSettings",
+    "Keywords": [
+      [
+        "private",
+        "privacy",
+        "secrecy"
+      ],
+      [
+        "by",
+        "defaults",
+        "defualt",
+        "standard"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "finding",
+        "locate",
+        "locating",
+        "search",
+        "for",
+        "is",
+        "where's",
+        "the"
+      ],
+      [
+        "sensors",
+        "senser"
+      ],
+      [
+        "gps",
+        "global",
+        "positioning",
+        "systems"
+      ],
+      [
+        "ambient",
+        "lighting",
+        "changes"
+      ],
+      [
+        "personal",
+        "information",
+        "persenal",
+        "private",
+        "informatien"
+      ],
+      [
+        "place",
+        "position",
+        "positian",
+        "new"
+      ],
+      [
+        "network",
+        "connections",
+        "netwerk",
+        "conection"
+      ],
+      [
+        "sensor",
+        "definition",
+        "what",
+        "is",
+        "a"
+      ],
+      [
+        "movement",
+        "movment",
+        "movemnet",
+        "motion"
+      ],
+      [
+        "detection",
+        "detecting",
+        "changes"
+      ],
+      [
+        "drop"
+      ],
+      [
+        "locations",
+        "change",
+        "another"
+      ],
+      [
+        "default",
+        "defualt",
+        "location"
+      ],
+      [
+        "geographic",
+        "locations",
+        "geografic",
+        "geografic",
+        "geografik"
+      ],
+      [
+        "latitude",
+        "laditude",
+        "longitude",
+        "longetude"
+      ],
+      [
+        "address",
+        "adress"
+      ],
+      [
+        "region",
+        "country",
+        "contry"
+      ],
+      [
+        "city"
+      ],
+      [
+        "orientation",
+        "orientatien",
+        "orientation",
+        "orientatian"
+      ],
+      [
+        "state"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage Web Credentials",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.CredentialManager",
+    "Keywords": [
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "word",
+        "pass-word",
+        "passwords",
+        "passwork",
+        "passwrod",
+        "pasword",
+        "paswrod"
+      ],
+      [
+        "passwords",
+        "web",
+        "stored",
+        "automatic",
+        "logon",
+        "credentials",
+        "network"
+      ],
+      [
+        "vault",
+        "locker"
+      ]
+    ]
+  },
+  {
+    "Name": "Manage Windows Credentials",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.CredentialManager /page ?SelectedVault=CredmanVault",
+    "Keywords": [
+      [
+        "administer",
+        "configure",
+        "managed",
+        "manages",
+        "managing",
+        "up",
+        "setup"
+      ],
+      [
+        "connections",
+        "go",
+        "online",
+        "intranet",
+        "lan",
+        "netowrk",
+        "networking",
+        "line",
+        "on-line",
+        "www"
+      ],
+      [
+        "word",
+        "pass-word",
+        "passwords",
+        "passwork",
+        "passwrod",
+        "pasword",
+        "paswrod"
+      ],
+      [
+        "passwords",
+        "web",
+        "stored",
+        "automatic",
+        "logon",
+        "credentials",
+        "network"
+      ],
+      [
+        "vault",
+        "locker"
+      ]
+    ]
+  },
+  {
+    "Name": "Back up and Restore (Windows 7)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.BackupAndRestore",
+    "Keywords": [
+      [
+        "up",
+        "backing",
+        "backuo",
+        "back-up",
+        "backups",
+        "back-ups",
+        "data",
+        "storage",
+        "incramental",
+        "incremental",
+        "saver",
+        "shadow",
+        "copies",
+        "copy"
+      ],
+      [
+        "data",
+        "recovering",
+        "recovers",
+        "recovery"
+      ],
+      [
+        "bring",
+        "back",
+        "change",
+        "recover",
+        "restore",
+        "back",
+        "rollback"
+      ],
+      [
+        "points",
+        "wizard",
+        "system",
+        "protection",
+        "restores",
+        "systemrestores"
+      ]
+    ]
+  },
+  {
+    "Name": "Restore data, files or computer from backup (Windows 7)",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.BackupAndRestore",
+    "Keywords": [
+      [
+        "up",
+        "backing",
+        "backuo",
+        "back-up",
+        "backups",
+        "back-ups",
+        "data",
+        "storage",
+        "incramental",
+        "incremental",
+        "saver",
+        "shadow",
+        "copies",
+        "copy"
+      ],
+      [
+        "data",
+        "recovering",
+        "recovers",
+        "recovery"
+      ],
+      [
+        "bring",
+        "back",
+        "change",
+        "recover",
+        "restore",
+        "back",
+        "rollback"
+      ],
+      [
+        "points",
+        "wizard",
+        "system",
+        "protection",
+        "restores",
+        "systemrestores"
+      ],
+      [
+        "recover",
+        "deleted",
+        "files",
+        "restore",
+        "get",
+        "lost",
+        "missing",
+        "rescue",
+        "retrieve",
+        "return",
+        "past",
+        "previous",
+        "protected",
+        "time",
+        "back",
+        "version"
+      ]
+    ]
+  },
+  {
+    "Name": "Save backup copies of your files with File History",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%SystemRoot%\\System32\\control.exe -name Microsoft.FileHistory",
+    "Keywords": [
+      [
+        "up",
+        "backing",
+        "backuo",
+        "back-up",
+        "backups",
+        "back-ups",
+        "data",
+        "storage",
+        "incramental",
+        "incremental",
+        "saver",
+        "shadow",
+        "copies",
+        "copy"
+      ],
+      [
+        "bring",
+        "back",
+        "change",
+        "recover",
+        "restore",
+        "back",
+        "rollback"
+      ],
+      [
+        "devices",
+        "divises",
+        "divicse",
+        "divices"
+      ],
+      [
+        "disk",
+        "drive",
+        "harddisk",
+        "hard-disk",
+        "harddrive",
+        "hard-drive"
+      ],
+      [
+        "guard",
+        "protect",
+        "secure",
+        "preserve"
+      ],
+      [
+        "sharing",
+        "shared",
+        "files",
+        "network",
+        "folder",
+        "target"
+      ],
+      [
+        "external",
+        "separate",
+        "seperate"
+      ],
+      [
+        "re-instate",
+        "re-set",
+        "recovery",
+        "recover",
+        "reinstall",
+        "factory",
+        "re-image",
+        "reimage",
+        "re-install",
+        "repair",
+        "restore",
+        "reinstate",
+        "reset",
+        "wipe",
+        "rollback",
+        "fix",
+        "troubleshoot",
+        "pc",
+        "refresh",
+        "erase",
+        "format"
+      ],
+      [
+        "archive",
+        "collection",
+        "files",
+        "keep",
+        "safe",
+        "personal",
+        "retain",
+        "save",
+        "library",
+        "history"
+      ],
+      [
+        "associate",
+        "exclude",
+        "migrate",
+        "move",
+        "reconnect",
+        "recommend",
+        "retention",
+        "settings",
+        "store"
+      ]
+    ]
+  },
+  {
+    "Name": "Restore your files with File History",
+    "Area": null,
+    "Type": "TaskLink",
+    "Command": "%windir%\\system32\\FileHistory.exe",
+    "Keywords": [
+      [
+        "up",
+        "backing",
+        "backuo",
+        "back-up",
+        "backups",
+        "back-ups",
+        "data",
+        "storage",
+        "incramental",
+        "incremental",
+        "saver",
+        "shadow",
+        "copies",
+        "copy"
+      ],
+      [
+        "bring",
+        "back",
+        "change",
+        "recover",
+        "restore",
+        "back",
+        "rollback"
+      ],
+      [
+        "recover",
+        "deleted",
+        "files",
+        "restore",
+        "get",
+        "lost",
+        "missing",
+        "rescue",
+        "retrieve",
+        "return",
+        "past",
+        "previous",
+        "protected",
+        "time",
+        "back",
+        "version"
+      ],
+      [
+        "archive",
+        "collection",
+        "files",
+        "keep",
+        "safe",
+        "personal",
+        "retain",
+        "save",
+        "library",
+        "history"
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
I keep the keywords because I think it can still be useful when calculate matching score, like show related results, helps users learn new task links, because the problem with task links is you never know them exist, only when you see them somewhere 😄 Thought?

Example: When user search "lan", without keywords list, the task link "Set up a virtual private network (VPN) connection" will not match, because it's not substring match. But with keywords list, it will show up because "lan" exists in keywords list.

And it has typo support too e.g. "netowrk" (I can't think of better name than typo support 🤣 )

```JSON
  {
    "Name": "Set up a virtual private network (VPN) connection",
    "Area": null,
    "Type": "TaskLink",
    "Command": "%windir%\\system32\\xwizard.exe RunWizard {7071EC75-663B-4bc1-A1FA-B97F3B917C55}",
    "Keywords": [
      [
        "activate",
        "add",
        "begin",
        "enable",
        "intsall",
        "invoke",
        "make",
        "up",
        "setting",
        "setup",
        "start",
        "on",
        "turnon",
        "unlock"
      ],
      [
        "connections",
        "go",
        "online",
        "intranet",
        "lan",
        "netowrk",
        "networking",
        "line",
        "on-line",
        "www"
      ],
      [
        "set-up",
        "confg",
        "configuration",
        "configure",
        "define",
        "management",
        "options",
        "personalise",
        "personalize",
        "up",
        "settings",
        "setup"
      ],
      [
        "virtual",
        "private",
        "network",
        "vpn",
        "workplace"
      ]
    ]
  }
```